### PR TITLE
fix(manager): make updates and native toggles reliable

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -31,6 +31,7 @@ Panel {
   // ------------------------------------------------------------------ plugins
 
   property var pluginRows: []
+  property var rememberedBarStates: ({})
 
   // The shell injects the PluginRegistry into the bar's `shell` (the built-in
   // Bar.qml exposes no `pluginRegistry` property itself), so resolve it there
@@ -190,6 +191,24 @@ Panel {
   property bool updatingAll: false
   property string updateSummary: ""
   property string updatingId: ""
+  // Detached update-runner plumbing (from PR #1): the helper survives the
+  // plugin reload that a successful update triggers, and the newly loaded
+  // panel reconnects to the same job via this runtime status file.
+  property string updateHelperPath: ""
+  property string updateRunnerPath: ""
+  readonly property string updateStateRoot: {
+    var runtime = Quickshell.env("XDG_RUNTIME_DIR")
+    return runtime && runtime !== ""
+      ? runtime + "/omaplug"
+      : Quickshell.env("HOME") + "/.cache/omaplug"
+  }
+  readonly property string updateStatusPath: root.updateStateRoot + "/update.status"
+  readonly property int completedUpdateJobMaxAgeSeconds: 300
+  property bool updateDetachedRunning: false
+  property bool updateAwaitingStart: false
+  property string updateExpectedJobId: ""
+  property string updateProbePid: ""
+  property int updateDeadProbeCount: 0
   // Full-page "check for updates" view (replaces the header inline progress).
   property bool updatesPageOpen: false
   // Streaming parse state for per-plugin progress.
@@ -402,6 +421,8 @@ Panel {
     if (st === "CHECK") return "Checking…"
     if (st === "CURRENT") return "Up to date"
     if (st === "UPDATE") return "Update available"
+    if (st === "LOCAL_CHANGES") return "Local changes"
+    if (st === "LOCAL") return "Local plugin"
     if (st === "ERROR") return "Error"
     return st
   }
@@ -411,7 +432,12 @@ Panel {
     if (st === "UPDATE") return Style.selectedStateColor(root.contentForeground, Color.accent)
     if (st === "ERROR") return Color.urgent
     if (st === "CURRENT") return Qt.darker(root.contentForeground, 1.6)
+    if (st === "LOCAL_CHANGES" || st === "LOCAL") return Qt.darker(root.contentForeground, 1.5)
     return Qt.darker(root.contentForeground, 1.4)
+  }
+
+  function updateErrorSuffix(count) {
+    return count > 0 ? " (" + count + " error" + (count === 1 ? "" : "s") + ")" : ""
   }
 
   readonly property int pendingUpdateCount: {
@@ -425,7 +451,8 @@ Panel {
 
   readonly property int enabledPluginCount: {
     var n = 0
-    for (var i = 0; i < root.pluginRows.length; i++) if (root.pluginRows[i].enabled) n++
+    for (var i = 0; i < root.pluginRows.length; i++)
+      if (root.pluginEnabled(root.pluginRows[i].id)) n++
     n
   }
 
@@ -594,30 +621,39 @@ Panel {
   function checkUpdates() {
     var reg = root.registry
     var dir = reg && reg.pluginsDir ? reg.pluginsDir : ""
-    console.log("pluginsDir=", dir)
-    if (!dir || root.checkingUpdates || root.updatingId !== "") return
+    if (!dir || root.updateHelperPath === "" || root.checkingUpdates || root.updateDetachedRunning) return
     root.checkingUpdates = true
     root.updateSummary = ""
+    root.updateStates = ({})
     root.updateCheckLineBuf = ""
     root.updateCheckProcessed = 0
     root.checkWatchdog.restart()
-    var script = ""
-      + "dirs=\"$0\"\n"
-      + "{ for d in \"$dirs\"/*/; do\n"
-      + "  [ -d \"$d/.git\" ] || continue\n"
-      + "  id=$(basename \"$d\")\n"
-      + "  echo \"CHECK|$id\"\n"
-      + "  if ! timeout 15 git -C \"$d\" fetch --quiet origin HEAD 2>/dev/null; then\n"
-      + "    echo \"ERROR|$id\"; continue\n"
-      + "  fi\n"
-      + "  if [ \"$(git -C \"$d\" rev-parse HEAD)\" = \"$(git -C \"$d\" rev-parse FETCH_HEAD)\" ]; then\n"
-      + "    echo \"CURRENT|$id\"\n"
-      + "  else\n"
-      + "    echo \"UPDATE|$id\"\n"
-      + "  fi\n"
-      + "done; } | { head -c 65536; cat >/dev/null; }"
-    updateCheckProcess.command = ["bash", "-c", script, dir]
+    updateCheckProcess.command = [root.updateHelperPath, dir]
     updateCheckProcess.running = true
+  }
+
+  // Per-line parser for plugin-state.sh output: tab-separated
+  // "<state>\t<folderKey>[<\torigin-url>]" records. States beyond CHECK are
+  // final; a non-empty origin-url also feeds pluginRepos so row links work.
+  function applyUpdateCheckLine(line) {
+    var cleanLine = String(line || "").trim()
+    if (cleanLine === "") return
+    var parts = cleanLine.split("\t")
+    if (parts.length < 2) return
+    var state = parts[0]
+    var key = parts[1]
+    if (["CHECK", "CURRENT", "UPDATE", "LOCAL_CHANGES", "LOCAL", "ERROR"].indexOf(state) < 0 || key === "") return
+    var st = {}
+    for (var k in root.updateStates) st[k] = root.updateStates[k]
+    st[key] = state
+    root.updateStates = st
+
+    if (parts.length > 2 && parts[2] !== "") {
+      var repos = {}
+      for (var r in root.pluginRepos) repos[r] = root.pluginRepos[r]
+      repos[key] = parts[2]
+      root.pluginRepos = repos
+    }
   }
 
   // Incremental per-line parse of the streaming check output. The collector's
@@ -635,87 +671,201 @@ Panel {
     var ready = root.updateCheckLineBuf.substring(0, idx + 1)
     root.updateCheckLineBuf = root.updateCheckLineBuf.substring(idx + 1)
     var lines = ready.split("\n")
-    for (var i = 0; i < lines.length; i++) {
-      var line = lines[i].trim()
-      if (line === "") continue
-      var parts = line.split("|")
-      if (parts.length < 2) continue
-      var st = {}
-      for (var k in root.updateStates) st[k] = root.updateStates[k]
-      st[parts[1]] = parts[0]
-      root.updateStates = st
-    }
+    for (var i = 0; i < lines.length; i++) root.applyUpdateCheckLine(lines[i])
   }
 
   // Finalize after the stream ends: flush any unterminated tail, then compute
   // the summary from the collected per-plugin states.
-  function finishUpdateCheck() {
+  function finishUpdateCheck(exitCode) {
     if (root.updateCheckLineBuf !== "") {
       var tail = root.updateCheckLineBuf.trim()
       root.updateCheckLineBuf = ""
-      if (tail !== "") root.applyUpdateCheckData(tail + "\n")
+      if (tail !== "") root.applyUpdateCheckLine(tail)
     }
     root.checkWatchdog.stop()
     root.checkingUpdates = false
+    var states = {}
+    for (var oldKey in root.updateStates) states[oldKey] = root.updateStates[oldKey]
+    for (var i = 0; i < root.updateCheckRows.length; i++) {
+      var sourceKey = root.updateCheckRows[i].sourceKey
+      if (!states[sourceKey] || states[sourceKey] === "CHECK") states[sourceKey] = "ERROR"
+    }
+    root.updateStates = states
     var updates = 0
     var errors = 0
     for (var key in root.updateStates) {
       if (root.updateStates[key] === "UPDATE") updates++
       else if (root.updateStates[key] === "ERROR") errors++
     }
-    if (updates === 0 && errors === 0)
+    if (exitCode !== 0)
+      root.updateSummary = "Update check failed" + root.updateErrorSuffix(errors)
+    else if (updates === 0 && errors === 0)
       root.updateSummary = ""
     else if (updates === 0)
-      root.updateSummary = "All plugins up to date" + (errors ? " (" + errors + " error)" : "")
+      root.updateSummary = "No updates available" + root.updateErrorSuffix(errors)
     else
       root.updateSummary = updates + " update" + (updates > 1 ? "s" : "") + " available"
-        + (errors ? " (" + errors + " error)" : "")
+        + root.updateErrorSuffix(errors)
   }
 
-  function updatePlugin(id) {
-    if (root.updatingId !== "") return
-    root.updatingId = id
-    root.updateSummary = "Updating " + id + "…"
-    updateProcess.command = ["bash", "-c", "omarchy plugin update \"$0\" --yes 2>&1 | { head -c 8192; cat >/dev/null; }; exit ${PIPESTATUS[0]}", id]
-    updateProcess.running = true
+  function updatePlugin(sourceKey) {
+    root.startDetachedUpdates([sourceKey])
   }
 
   function updateAll() {
-    if (root.updatingId !== "" || root.checkingUpdates || root.updatingAll) return
-    var pending = 0
-    for (var key in root.updateStates) {
-      if (root.updateStates[key] === "UPDATE") pending++
+    if (root.checkingUpdates || root.updateDetachedRunning) return
+    var ids = []
+    for (var i = 0; i < root.updateCheckRows.length; i++) {
+      var key = root.updateCheckRows[i].sourceKey
+      if (root.updateStates[key] === "UPDATE") ids.push(key)
     }
-    if (pending === 0) return
-    root.updatingAll = true
-    root.updateSummary = "Updating all " + pending + "…"
-    updateAllProcess.command = ["bash", "-c", "omarchy plugin update --yes 2>&1 | { head -c 8192; cat >/dev/null; }; exit ${PIPESTATUS[0]}"]
-    updateAllProcess.running = true
+    root.startDetachedUpdates(ids)
   }
 
-  function onUpdateAllFinished(exitCode) {
+  // Launch only the repositories proven updateable by the preceding check.
+  // The helper is detached because the first successful merge makes Omarchy
+  // unload this panel; progress lives at a stable runtime path so the newly
+  // loaded instance can reconnect to the same job.
+  function startDetachedUpdates(ids) {
+    if (!ids || ids.length === 0 || root.checkingUpdates || root.updateDetachedRunning) return
+    if (root.updateRunnerPath === "" || root.updateStatusPath === "") {
+      root.updateSummary = "Update helper not found"
+      return
+    }
+
+    root.updateDetachedRunning = true
+    root.updateAwaitingStart = true
+    root.updateExpectedJobId = Date.now().toString(36) + "-" + Math.floor(Math.random() * 0x1000000).toString(36)
+    root.updateProbePid = ""
+    root.updateDeadProbeCount = 0
+    root.updatingAll = ids.length > 1
+    root.updatingId = ids.length === 1 ? ids[0] : ""
+    root.updateSummary = ids.length === 1
+      ? "Updating " + ids[0] + "…"
+      : "Updating 0 of " + ids.length + "…"
+
+    var launch = [root.updateRunnerPath, root.updateStatusPath, root.updateExpectedJobId]
+    for (var i = 0; i < ids.length; i++) launch.push(ids[i])
+    try {
+      Quickshell.execDetached(launch)
+    } catch (e) {
+      root.markUpdateInterrupted("Update could not start")
+      return
+    }
+    updateStartTimer.restart()
+    updateStatusPoll.restart()
+  }
+
+  function applyUpdateJobStatus() {
+    var text = ""
+    try { text = updateStatusFile.text() } catch (e) { return }
+    if (String(text || "").trim() === "") return
+
+    var lines = String(text).split("\n")
+    var jobId = ""
+    var pid = ""
+    var total = 0
+    var current = ""
+    var completed = 0
+    var failures = 0
+    var finished = 0
+    var done = false
+    var outcomes = {}
+
+    for (var i = 0; i < lines.length; i++) {
+      var parts = lines[i].split("\t")
+      var event = parts[0]
+      if (event === "job") jobId = parts[1] || ""
+      else if (event === "pid") pid = parts[1] || ""
+      else if (event === "total") total = parseInt(parts[1] || "0")
+      else if (event === "start") current = parts[1] || ""
+      else if (event === "ok") {
+        outcomes[parts[1]] = "CURRENT"
+        completed++
+        if (current === parts[1]) current = ""
+      } else if (event === "failed") {
+        outcomes[parts[1]] = "ERROR"
+        completed++
+        failures++
+        if (current === parts[1]) current = ""
+      } else if (event === "finished") {
+        finished = parseInt(parts[1] || "0")
+      } else if (event === "done") {
+        done = true
+        completed = parseInt(parts[1] || String(completed)) + parseInt(parts[2] || String(failures))
+        failures = parseInt(parts[2] || String(failures))
+      }
+    }
+
+    // A previous completed job may still be present while the newly detached
+    // helper starts. Ignore it until this panel sees its own job id. A panel
+    // recreated by Omarchy's hot reload has no expectation and adopts the
+    // current job from disk instead.
+    var expectingJob = root.updateExpectedJobId !== ""
+    if (jobId === "" || (expectingJob && jobId !== root.updateExpectedJobId)) return
+    if (!expectingJob && done && finished > 0
+        && Date.now() / 1000 - finished > root.completedUpdateJobMaxAgeSeconds) return
+    root.updateExpectedJobId = jobId
+    root.updateAwaitingStart = false
+    updateStartTimer.stop()
+    if (pid !== root.updateProbePid) {
+      root.updateProbePid = pid
+      root.updateDeadProbeCount = 0
+    }
+
+    var states = {}
+    for (var key in root.updateStates) states[key] = root.updateStates[key]
+    for (var outcome in outcomes) states[outcome] = outcomes[outcome]
+    root.updateStates = states
+    root.updatingAll = total > 1
+    root.updatingId = current
+
+    if (done) {
+      root.updateDetachedRunning = false
+      root.updateAwaitingStart = false
+      root.updatingAll = false
+      root.updatingId = ""
+      root.updateProbePid = ""
+      root.updateDeadProbeCount = 0
+      updateStartTimer.stop()
+      updateStatusPoll.stop()
+      var successes = Math.max(0, completed - failures)
+      if (failures === 0)
+        root.updateSummary = successes === 1 ? "1 plugin updated" : successes + " plugins updated"
+      else
+        root.updateSummary = successes + " updated, " + failures + " failed"
+      root.refreshPlugins()
+      return
+    }
+
+    root.updateDetachedRunning = true
+    root.updateSummary = total > 1
+      ? "Updating " + completed + " of " + total + (current ? ": " + current : "") + "…"
+      : (current ? "Updating " + current + "…" : "Preparing update…")
+    updateStatusPoll.restart()
+  }
+
+  function recoverExistingUpdateOrFailStart() {
+    if (!root.updateAwaitingStart) return
+    root.updateAwaitingStart = false
+    root.updateExpectedJobId = ""
+    root.updateDetachedRunning = false
+    root.applyUpdateJobStatus()
+    if (!root.updateDetachedRunning)
+      root.markUpdateInterrupted("Update could not start. Another update may already be running.")
+  }
+
+  function markUpdateInterrupted(message) {
+    root.updateDetachedRunning = false
+    root.updateAwaitingStart = false
     root.updatingAll = false
-    if (exitCode === 0)
-      root.updateSummary = "All updates applied"
-    else {
-      var err = String(updateStdout.text || "").trim()
-      root.updateSummary = "Bulk update failed" + (err ? ": " + err : "")
-    }
-    root.refreshPlugins()
-    Qt.callLater(function() { root.checkUpdates() })
-  }
-
-  function onUpdateFinished(exitCode) {
-    var id = root.updatingId
     root.updatingId = ""
-    if (exitCode === 0)
-      root.updateSummary = "Updated " + id
-    else {
-      var err = String(updateStdout.text || "").trim()
-      root.updateSummary = "Update of " + id + " failed" + (err ? ": " + err : "")
-    }
-    root.refreshPlugins()
-    Qt.callLater(function() { root.checkUpdates() })
+    root.updateExpectedJobId = ""
+    root.updateProbePid = ""
+    root.updateDeadProbeCount = 0
+    updateStartTimer.stop()
+    updateStatusPoll.stop()
+    root.updateSummary = message || "Update interrupted. Check again."
   }
 
   // Fetches the public marketplace catalog (capped at 2 MB like every other
@@ -799,7 +949,8 @@ Panel {
 
   property Process updateCheckProcess: Process {
     onExited: function(exitCode) {
-      root.finishUpdateCheck()
+      console.log("updateCheckProcess onExited exitCode=", exitCode)
+      root.finishUpdateCheck(exitCode)
     }
     stdout: StdioCollector {
       id: updateCheckStdout
@@ -808,17 +959,55 @@ Panel {
     }
   }
 
-  property Process updateProcess: Process {
+  // Liveness probe for the detached update runner: kill -0 the recorded pid;
+  // two consecutive failures mean the helper died without a done marker.
+  property Process updateProbeProcess: Process {
     onExited: function(exitCode) {
-      root.onUpdateFinished(exitCode)
+      if (!root.updateDetachedRunning || root.updateAwaitingStart) return
+      if (exitCode === 0) {
+        root.updateDeadProbeCount = 0
+        return
+      }
+      root.updateDeadProbeCount++
+      updateStatusFile.reload()
+      if (root.updateDeadProbeCount >= 2)
+        root.markUpdateInterrupted()
     }
-    stdout: StdioCollector { id: updateStdout; waitForEnd: true }
   }
 
-  property Process updateAllProcess: Process {
-    onExited: function(exitCode) {
-      console.log("updateAllProcess onExited exitCode=", exitCode)
-      root.onUpdateAllFinished(exitCode)
+  FileView {
+    id: updateStatusFile
+    path: root.updateStatusPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.applyUpdateJobStatus()
+    onFileChanged: updateStatusFile.reload()
+  }
+
+  Timer {
+    id: updateStartTimer
+    interval: 3000
+    repeat: false
+    onTriggered: root.recoverExistingUpdateOrFailStart()
+  }
+
+  Timer {
+    id: updateStatusPoll
+    interval: 500
+    repeat: true
+    running: root.updateDetachedRunning
+    onTriggered: updateStatusFile.reload()
+  }
+
+  Timer {
+    interval: 2000
+    repeat: true
+    running: root.updateDetachedRunning && !root.updateAwaitingStart
+    onTriggered: {
+      if (!updateProbeProcess.running && /^[0-9]+$/.test(root.updateProbePid)) {
+        updateProbeProcess.command = ["bash", "-c", 'kill -0 "$0" 2>/dev/null', root.updateProbePid]
+        updateProbeProcess.running = true
+      }
     }
   }
 
@@ -1101,14 +1290,17 @@ Panel {
       var m = reg.installedPlugins[id]
       if (!m || typeof m !== "object") continue
       var sourceDir = String(m.__sourceDir || "")
+      var kinds = Array.isArray(m.kinds) ? m.kinds : []
+      var isBarOption = kinds.indexOf("bar") !== -1
+      var isBarWidget = kinds.indexOf("bar-widget") !== -1
       rows.push({
         id: id,
         name: m.name || id,
         version: m.version || "unknown",
         author: m.author || "",
         description: m.description || "",
-        kinds: (m.kinds || []).join(", "),
-        enabled: reg.isEnabled(id) === true,
+        kinds: kinds.join(", "),
+        canDisable: !isBarOption,
         firstParty: m.__isFirstParty === true,
         sourceDir: sourceDir,
         sourceKey: sourceDir.replace(/\/+$/, "").split("/").pop() || "",
@@ -1125,10 +1317,78 @@ Panel {
     root.scanPluginRepos()
   }
 
+  function barStateFor(id) {
+    var reg = root.registry
+    var config = reg && typeof reg.shellConfigProvider === "function"
+      ? reg.shellConfigProvider()
+      : null
+    var layout = config && config.bar ? config.bar.layout : null
+    if (!layout) return null
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var entries = layout[sections[s]]
+      if (!Array.isArray(entries)) continue
+      for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i]
+        var entryId = reg && typeof reg.barEntryId === "function"
+          ? reg.barEntryId(entry)
+          : (entry && typeof entry === "object" ? entry.id : entry)
+        if (String(entryId || "") === String(id))
+          return {
+            section: sections[s],
+            index: i,
+            entry: entry && typeof entry === "object"
+              ? JSON.parse(JSON.stringify(entry))
+              : { id: String(entryId) }
+          }
+      }
+    }
+    return null
+  }
+
+  function rememberBarState(id, state) {
+    var next = {}
+    for (var key in root.rememberedBarStates)
+      next[key] = root.rememberedBarStates[key]
+    if (state) next[String(id)] = state
+    else delete next[String(id)]
+    root.rememberedBarStates = next
+  }
+
+  function restoreBarSettings(id, state) {
+    var reg = root.registry
+    var entry = state ? state.entry : null
+    if (!entry || !reg || typeof reg.setBarWidget !== "function") return
+    var location = root.barStateFor(id)
+    if (!location) return
+    var selector = { section: location.section, index: location.index }
+    for (var key in entry) {
+      if (key === "id") continue
+      var error = reg.setBarWidget(id, key, entry[key], selector)
+      if (error) console.warn("Could not restore " + id + " setting " + key + ": " + error)
+    }
+  }
+
   function setPluginEnabled(id, value) {
     var reg = root.registry
     if (!reg || typeof reg.setEnabled !== "function") return
-    reg.setEnabled(id, value)
+    // Bar options cannot be disabled directly (they are bar placements);
+    // guard here so a stale UI can't fight the registry.
+    for (var i = 0; i < root.pluginRows.length; i++) {
+      var row = root.pluginRows[i]
+      if (row.id === id && value === false && row.canDisable === false) return
+    }
+    var remembered = value ? root.rememberedBarStates[String(id)] : null
+    var current = value ? null : root.barStateFor(id)
+    var changed = remembered
+      ? reg.setEnabled(id, true, remembered)
+      : reg.setEnabled(id, value)
+    if (!changed) return
+    if (!value && current) root.rememberBarState(id, current)
+    else if (value && remembered) {
+      root.restoreBarSettings(id, remembered)
+      root.rememberBarState(id, null)
+    }
   }
 
   function registryRevision() {
@@ -1136,18 +1396,36 @@ Panel {
     return reg ? reg.registryRevision : 0
   }
 
+  function pluginEnabled(id) {
+    root.registryRevision()
+    var reg = root.registry
+    var manifest = reg && reg.installedPlugins ? reg.installedPlugins[id] : null
+    if (!manifest) return false
+    var kinds = Array.isArray(manifest.kinds) ? manifest.kinds : []
+    // Built-in widgets remain loadable even while absent from the bar, so the
+    // user-facing toggle follows their actual placement instead of isEnabled().
+    return kinds.indexOf("bar-widget") !== -1 && typeof reg.inBar === "function"
+      ? reg.inBar(id) === true
+      : reg.isEnabled(id) === true
+  }
+
   Connections {
     target: root.registry
     function onRegistryRevisionChanged() {
       root.invalidateGlyphCache()
+    }
+    function onScanFinished() {
       root.refreshPlugins()
     }
   }
 
   Component.onCompleted: {
     console.log("Panel.qml loaded, filterMode=", root.filterMode, "rows=", root.pluginRows.length)
+    root.updateHelperPath = String(Qt.resolvedUrl("plugin-state.sh")).replace(/^file:\/\//, "")
+    root.updateRunnerPath = String(Qt.resolvedUrl("update-helper.sh")).replace(/^file:\/\//, "")
     refreshPlugins()
     fetchMarketplace()
+    Qt.callLater(function() { updateStatusFile.reload() })
   }
 
   // ------------------------------------------------------------- open / close
@@ -1354,7 +1632,7 @@ Panel {
           Button {
             iconText: "\uf021"
             tooltipText: "Check updates"
-            enabled: !root.checkingUpdates && root.updatingId === "" && !root.updatingAll
+            enabled: !root.checkingUpdates && !root.updateDetachedRunning
             foreground: root.contentForeground
             accent: Color.accent
             fontFamily: root.contentFontFamily
@@ -1467,6 +1745,7 @@ Panel {
           delegate: Item {
             id: rowWrapper
             required property var modelData
+            required property int index
             width: pluginList.width
             height: pluginRowDelegate.height + Style.space(9)
 
@@ -1915,15 +2194,19 @@ Panel {
                   // Inline switch: solid accent track when ON so it reads the
                   // same as the accent-colored author / "View on marketplace"
                   // links (ToggleSwitch's fill is too faint at 0.18 alpha).
+                  // Gated like the PR's native toggle: bar options that are
+                  // active cannot be switched off directly.
                   Item {
                     id: toggle
-                    readonly property bool checked: modelData.enabled
+                    readonly property bool checked: root.pluginEnabled(rowWrapper.modelData.id)
+                    readonly property bool canToggle: rowWrapper.modelData.canDisable || !toggle.checked
                     readonly property int _h: Math.max(22, Math.round(Style.spacing.controlHeight * 0.55))
                     readonly property int _w: Math.round(_h * 1.9)
                     readonly property int _k: Math.max(6, Math.round(_h * 0.72))
                     readonly property int _inset: Math.max(1, Math.round((_h - _k) / 2))
                     implicitWidth: _w
                     implicitHeight: _h
+                    opacity: canToggle ? 1 : 0.4
                     Layout.alignment: Qt.AlignVCenter
 
                     Rectangle {
@@ -1949,8 +2232,11 @@ Panel {
 
                     MouseArea {
                       anchors.fill: parent
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.callLater(function() { root.setPluginEnabled(modelData.id, !modelData.enabled) })
+                      cursorShape: toggle.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
+                      onClicked: {
+                        if (!toggle.canToggle) return
+                        Qt.callLater(function() { root.setPluginEnabled(rowWrapper.modelData.id, !toggle.checked) })
+                      }
                     }
                   }
 
@@ -2008,8 +2294,8 @@ Panel {
                   Button {
                     visible: modelData.updatable
                       && root.updateStates[modelData.sourceKey] === "UPDATE"
-                    text: root.updatingId === modelData.id ? "Updating…" : "Update"
-                    enabled: root.updatingId === "" && !root.updatingAll
+                    text: root.updatingId === modelData.sourceKey ? "Updating…" : "Update"
+                    enabled: !root.updateDetachedRunning
                     bordered: true
                     // Keep the idle border but drop it while hovered.
                     borderSpec: hot ? Border.none()
@@ -2021,7 +2307,7 @@ Panel {
                     horizontalPadding: Style.space(8)
                     verticalPadding: Style.space(3)
                     Layout.fillWidth: true
-                    onClicked: root.updatePlugin(modelData.id)
+                    onClicked: root.updatePlugin(modelData.sourceKey)
                   }
                 }
               }
@@ -2350,12 +2636,13 @@ Panel {
 
               Button {
                 readonly property string st: String(root.updateStates[modelData.sourceKey] || "")
-                visible: st === "CURRENT" || st === "UPDATE" || st === "ERROR"
-                // Icon + label: a "UPDATE" pill when a newer version is
+                visible: st === "CURRENT" || st === "UPDATE" || st === "LOCAL_CHANGES"
+                  || st === "LOCAL" || st === "ERROR"
+                // Icon + label: an "UPDATE" pill when a newer version is
                 // available (clickable to update), a plain check otherwise.
                 text: st === "UPDATE" ? "\uEAC2 UPDATE" : "\uF00C"
-                enabled: st === "UPDATE"
-                onClicked: root.updatePlugin(modelData.id)
+                enabled: st === "UPDATE" && !root.updateDetachedRunning
+                onClicked: root.updatePlugin(modelData.sourceKey)
                 bordered: true
                 // Keep the idle border but drop it on hover, matching the
                 // other action buttons.
@@ -2416,7 +2703,7 @@ Panel {
           Button {
             text: root.updatingAll ? "Updating all…" : "Update all"
             enabled: root.pendingUpdateCount > 0
-              && !root.checkingUpdates && root.updatingId === "" && !root.updatingAll
+              && !root.checkingUpdates && !root.updateDetachedRunning
             visible: root.pendingUpdateCount > 0
             foreground: root.contentForeground
             accent: Color.accent
@@ -2472,9 +2759,14 @@ Panel {
           implicitWidth: Style.space(180)
 
           property var plugin: root.rowMenuPlugin()
+          readonly property bool pluginIsEnabled: plugin ? root.pluginEnabled(plugin.id) : false
 
           Button {
-            text: rowMenuColumn.plugin && rowMenuColumn.plugin.enabled ? "Disable" : "Enable"
+            text: rowMenuColumn.pluginIsEnabled
+              ? (rowMenuColumn.plugin.canDisable ? "Disable" : "Active bar")
+              : "Enable"
+            enabled: rowMenuColumn.plugin
+              && (rowMenuColumn.plugin.canDisable || !rowMenuColumn.pluginIsEnabled)
             foreground: root.contentForeground
             accent: Color.accent
             fontFamily: root.contentFontFamily
@@ -2484,7 +2776,7 @@ Panel {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft
             onClicked: {
-              root.setPluginEnabled(root.rowMenuId, !rowMenuColumn.plugin.enabled)
+              root.setPluginEnabled(root.rowMenuId, !rowMenuColumn.pluginIsEnabled)
               root.closeRowMenu()
             }
           }

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Omaplug is listed on the marketplace: [omarchyplugins.com/plugin.html?id=omaplug
 ## What it can do
 
 - **🔌 Enable / disable** — every discovered plugin (Omarchy's own and third-party) gets a simple toggle. Flipping it goes through the same registry the `omarchy plugin enable/disable` command uses, so what you see here is always what's really running.
-- **🔄 Check for updates** — scans every git-managed plugin, peeks at its remote, and tells you per plugin if it's *Up to date*, an *Update is available*, or something went *wrong* — streamed live as it checks.
-- **⬆️ Update (or update everything)** — apply one update, or blast through every plugin with a pending update in a single click.
+- **🔄 Check for updates** — scans every installed third-party plugin and distinguishes clean updates from local plugins, symlinked development plugins, local changes, and genuine fetch errors.
+- **⬆️ Update (or update everything)** — apply one update, or finish every proven-safe pending update from a single click, even while Omarchy reloads changed plugins.
 - **➕ Install** — paste a git repo URL and add a plugin in one step. It'll warn you first that plugins run as unsandboxed code, because honesty is the default here.
 - **🗑️ Remove** — third-party plugins only. Trash one, or enter Select mode to check several and remove them all at once (with a confirmation, no accidents).
 - **🔗 Source link** — every git-managed plugin gets a `SOURCE` button that jumps straight to its repo page.

--- a/plugin-state.sh
+++ b/plugin-state.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Classify every installed third-party plugin for the update UI.
+#
+# Output is tab-separated and streamed one record at a time:
+#   CHECK          <id>
+#   <state>        <id>    <origin-url>    <detail>
+#
+# Stable states are CURRENT, UPDATE, LOCAL_CHANGES, LOCAL, and ERROR.
+
+set -uo pipefail
+
+export GIT_TERMINAL_PROMPT=0
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+PLUGINS_DIR="${1:-$HOME/.config/omarchy/plugins}"
+
+emit_state() {
+  local state="$1"
+  local id="$2"
+  local url="${3:-}"
+  local detail="${4:-}"
+  printf '%s\t%s\t%s\t%s\n' "$state" "$id" "$url" "$detail"
+}
+
+origin_url() {
+  local dir="$1"
+  local url
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
+  url=${url//$'\t'/ }
+  url=${url//$'\r'/ }
+  url=${url//$'\n'/ }
+  printf '%s' "$url"
+}
+
+[[ -d $PLUGINS_DIR ]] || exit 0
+
+for dir in "$PLUGINS_DIR"/*; do
+  [[ -d $dir && -f $dir/manifest.json ]] || continue
+
+  id="${dir##*/}"
+  printf 'CHECK\t%s\n' "$id"
+
+  # Omarchy uses symlinks for development plugins. Even when the target is a
+  # Git repository, updating it here would mutate its source workspace.
+  if [[ -L $dir ]]; then
+    url=""
+    resolved=$(realpath -e -- "$dir" 2>/dev/null || true)
+    top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || true)
+    if [[ -n $resolved && $resolved == "$top" ]]; then
+      url=$(origin_url "$dir")
+    fi
+    emit_state LOCAL "$id" "$url" symlink
+    continue
+  fi
+
+  # Match the public Omarchy updater: only a checkout with its own .git
+  # directory is managed. Plain folders and linked worktrees stay local.
+  if [[ ! -d $dir/.git ]]; then
+    emit_state LOCAL "$id" "" not-git-managed
+    continue
+  fi
+
+  url=$(origin_url "$dir")
+  if [[ -z $url ]]; then
+    emit_state LOCAL "$id" "" no-origin
+    continue
+  fi
+
+  if ! head=$(git -C "$dir" rev-parse --verify HEAD 2>/dev/null); then
+    emit_state LOCAL "$id" "$url" no-commits
+    continue
+  fi
+
+  if ! git -C "$dir" symbolic-ref --quiet HEAD >/dev/null 2>&1; then
+    emit_state LOCAL_CHANGES "$id" "$url" detached
+    continue
+  fi
+
+  if ! changes=$(git -C "$dir" status --porcelain --untracked-files=normal 2>/dev/null); then
+    emit_state ERROR "$id" "$url" inspect-failed
+    continue
+  elif [[ -n $changes ]]; then
+    emit_state LOCAL_CHANGES "$id" "$url" modified
+    continue
+  fi
+
+  if ! timeout 15 git -C "$dir" fetch --quiet origin HEAD 2>/dev/null; then
+    emit_state ERROR "$id" "$url" fetch-failed
+    continue
+  fi
+
+  remote=$(git -C "$dir" rev-parse --verify FETCH_HEAD 2>/dev/null || true)
+  if [[ -z $remote ]]; then
+    emit_state ERROR "$id" "$url" invalid-fetch-head
+  elif [[ $head == "$remote" ]]; then
+    emit_state CURRENT "$id" "$url" equal
+  elif git -C "$dir" merge-base --is-ancestor "$head" "$remote" 2>/dev/null; then
+    emit_state UPDATE "$id" "$url" behind
+  elif git -C "$dir" merge-base --is-ancestor "$remote" "$head" 2>/dev/null; then
+    emit_state LOCAL_CHANGES "$id" "$url" ahead
+  else
+    emit_state LOCAL_CHANGES "$id" "$url" diverged
+  fi
+done

--- a/tests/DetachedLaunch.qml
+++ b/tests/DetachedLaunch.qml
@@ -1,0 +1,21 @@
+import QtQuick
+import Quickshell
+
+ShellRoot {
+  Component.onCompleted: {
+    Quickshell.execDetached([
+      Quickshell.env("OMAPLUG_TEST_HELPER"),
+      Quickshell.env("OMAPLUG_TEST_STATUS"),
+      "job-quickshell",
+      "slow",
+      "good"
+    ])
+    exitTimer.start()
+  }
+
+  Timer {
+    id: exitTimer
+    interval: 50
+    onTriggered: Qt.quit()
+  }
+}

--- a/tests/plugin-state-test.sh
+++ b/tests/plugin-state-test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+PLUGINS="$TMP/plugins"
+SEED="$TMP/seed"
+REMOTE="$TMP/origin.git"
+mkdir -p -- "$PLUGINS"
+
+git init --bare -q "$REMOTE"
+git -C "$REMOTE" symbolic-ref HEAD refs/heads/main
+git init -q -b main "$SEED"
+git -C "$SEED" config user.name "Omaplug Tests"
+git -C "$SEED" config user.email "omaplug-tests@example.invalid"
+printf '{"id":"fixture"}\n' > "$SEED/manifest.json"
+git -C "$SEED" add manifest.json
+git -C "$SEED" commit -qm "initial"
+git -C "$SEED" remote add origin "$REMOTE"
+git -C "$SEED" push -q -u origin main
+
+# Keep one checkout at the initial commit. It becomes behind after the second
+# upstream commit, and a local commit on a copy of it creates a divergence.
+git clone -q "$REMOTE" "$PLUGINS/behind"
+git clone -q "$REMOTE" "$PLUGINS/diverged"
+
+printf '{"id":"fixture","version":2}\n' > "$SEED/manifest.json"
+git -C "$SEED" add manifest.json
+git -C "$SEED" commit -qm "upstream update"
+git -C "$SEED" push -q
+
+git clone -q "$REMOTE" "$PLUGINS/current"
+git clone -q "$REMOTE" "$PLUGINS/dirty"
+git clone -q "$REMOTE" "$PLUGINS/ahead"
+git clone -q "$REMOTE" "$PLUGINS/fetch-error"
+git clone -q "$REMOTE" "$PLUGINS/detached"
+
+printf '\n' >> "$PLUGINS/dirty/manifest.json"
+git -C "$PLUGINS/detached" checkout -q --detach
+
+git -C "$PLUGINS/ahead" config user.name "Omaplug Tests"
+git -C "$PLUGINS/ahead" config user.email "omaplug-tests@example.invalid"
+printf '{"id":"fixture","version":3}\n' > "$PLUGINS/ahead/manifest.json"
+git -C "$PLUGINS/ahead" add manifest.json
+git -C "$PLUGINS/ahead" commit -qm "local commit"
+
+git -C "$PLUGINS/diverged" config user.name "Omaplug Tests"
+git -C "$PLUGINS/diverged" config user.email "omaplug-tests@example.invalid"
+printf '{"id":"fixture","local":true}\n' > "$PLUGINS/diverged/manifest.json"
+git -C "$PLUGINS/diverged" add manifest.json
+git -C "$PLUGINS/diverged" commit -qm "divergent local commit"
+
+git -C "$PLUGINS/fetch-error" remote set-url origin "$TMP/missing.git"
+
+mkdir -p -- "$PLUGINS/plain" "$PLUGINS/no-origin"
+printf '{"id":"plain"}\n' > "$PLUGINS/plain/manifest.json"
+printf '{"id":"no-origin"}\n' > "$PLUGINS/no-origin/manifest.json"
+git init -q "$PLUGINS/no-origin"
+git -C "$PLUGINS/no-origin" config user.name "Omaplug Tests"
+git -C "$PLUGINS/no-origin" config user.email "omaplug-tests@example.invalid"
+git -C "$PLUGINS/no-origin" add manifest.json
+git -C "$PLUGINS/no-origin" commit -qm "local plugin"
+ln -s -- "$PLUGINS/current" "$PLUGINS/symlinked"
+
+OUTPUT=$($ROOT/plugin-state.sh "$PLUGINS")
+
+state_for() {
+  local id="$1"
+  awk -F '\t' -v id="$id" '$1 != "CHECK" && $2 == id { print $1 }' <<< "$OUTPUT"
+}
+
+detail_for() {
+  local id="$1"
+  awk -F '\t' -v id="$id" '$1 != "CHECK" && $2 == id { print $4 }' <<< "$OUTPUT"
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local label="$3"
+  if [[ $actual != "$expected" ]]; then
+    printf 'FAIL: %s: expected %q, got %q\n' "$label" "$expected" "$actual" >&2
+    printf '%s\n' "$OUTPUT" >&2
+    exit 1
+  fi
+}
+
+assert_eq CURRENT "$(state_for current)" current
+assert_eq UPDATE "$(state_for behind)" behind
+assert_eq LOCAL_CHANGES "$(state_for dirty)" dirty
+assert_eq modified "$(detail_for dirty)" dirty-detail
+assert_eq LOCAL_CHANGES "$(state_for detached)" detached
+assert_eq detached "$(detail_for detached)" detached-detail
+assert_eq LOCAL_CHANGES "$(state_for ahead)" ahead
+assert_eq ahead "$(detail_for ahead)" ahead-detail
+assert_eq LOCAL_CHANGES "$(state_for diverged)" diverged
+assert_eq diverged "$(detail_for diverged)" diverged-detail
+assert_eq LOCAL "$(state_for plain)" plain
+assert_eq LOCAL "$(state_for no-origin)" no-origin
+assert_eq LOCAL "$(state_for symlinked)" symlinked
+assert_eq ERROR "$(state_for fetch-error)" fetch-error
+
+current_url=$(awk -F '\t' '$1 == "CURRENT" && $2 == "current" { print $3 }' <<< "$OUTPUT")
+assert_eq "$REMOTE" "$current_url" origin-url-without-trailing-space
+
+printf 'plugin-state-test: ok\n'

--- a/tests/quickshell-detached-test.sh
+++ b/tests/quickshell-detached-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+if ! command -v quickshell >/dev/null 2>&1; then
+  printf 'quickshell-detached-test: skipped (quickshell not installed)\n'
+  exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+BIN="$TMP/bin"
+TEST_HOME="$TMP/home"
+PLUGINS="$TEST_HOME/.config/omarchy/plugins"
+STATUS="$TMP/update.status"
+mkdir -p -- "$BIN" "$PLUGINS"
+
+for id in slow good; do
+  dir="$PLUGINS/$id"
+  git init -q -b main "$dir"
+  git -C "$dir" config user.name "Omaplug Tests"
+  git -C "$dir" config user.email "omaplug-tests@example.invalid"
+  printf '{"id":"%s"}\n' "$id" > "$dir/manifest.json"
+  git -C "$dir" add manifest.json
+  git -C "$dir" commit -qm "fixture"
+done
+
+cat > "$BIN/omarchy" <<'EOF'
+#!/bin/bash
+[[ ${3:-} == slow ]] && sleep 0.4
+printf 'updated %s\n' "${3:-}"
+EOF
+chmod +x "$BIN/omarchy"
+
+PATH="$BIN:$PATH" \
+HOME="$TEST_HOME" \
+OMAPLUG_TEST_HELPER="$ROOT/update-helper.sh" \
+OMAPLUG_TEST_STATUS="$STATUS" \
+QT_QPA_PLATFORM=offscreen \
+  quickshell --no-color -p "$ROOT/tests/DetachedLaunch.qml" >/dev/null 2>&1
+
+for _ in {1..200}; do
+  grep -Fqx $'done\t2\t0' "$STATUS" 2>/dev/null && break
+  sleep 0.01
+done
+
+grep -Fqx $'job\tjob-quickshell' "$STATUS"
+grep -Fqx $'done\t2\t0' "$STATUS"
+printf 'quickshell-detached-test: ok\n'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+"$ROOT/plugin-state-test.sh"
+"$ROOT/update-helper-test.sh"
+"$ROOT/quickshell-detached-test.sh"

--- a/tests/update-helper-test.sh
+++ b/tests/update-helper-test.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf -- "$TMP"' EXIT
+
+BIN="$TMP/bin"
+LOG="$TMP/calls.log"
+STATUS="$TMP/update.status"
+TEST_HOME="$TMP/home"
+PLUGINS="$TEST_HOME/.config/omarchy/plugins"
+mkdir -p -- "$BIN" "$PLUGINS"
+
+make_plugin() {
+  local id="$1"
+  local dir="$PLUGINS/$id"
+  git init -q -b main "$dir"
+  git -C "$dir" config user.name "Omaplug Tests"
+  git -C "$dir" config user.email "omaplug-tests@example.invalid"
+  printf '{"id":"%s"}\n' "$id" > "$dir/manifest.json"
+  git -C "$dir" add manifest.json
+  git -C "$dir" commit -qm "fixture"
+}
+
+for id in good fail slow dirty detached; do make_plugin "$id"; done
+printf '\n' >> "$PLUGINS/dirty/manifest.json"
+git -C "$PLUGINS/detached" checkout -q --detach
+ln -s -- "$PLUGINS/good" "$PLUGINS/linked"
+
+cat > "$BIN/omarchy" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$OMAPLUG_TEST_LOG"
+case "${3:-}" in
+  slow) sleep 0.4 ;;
+esac
+if [[ ${3:-} == fail ]]; then
+  printf 'could not update %s\n' "$3" >&2
+  exit 7
+fi
+printf 'updated %s\n' "${3:-}"
+EOF
+chmod +x "$BIN/omarchy"
+
+export PATH="$BIN:$PATH"
+export OMAPLUG_TEST_LOG="$LOG"
+export HOME="$TEST_HOME"
+
+# A prior run may have left a status file created under a permissive umask.
+# The helper must tighten it before writing any job details.
+: > "$STATUS"
+chmod 0644 "$STATUS"
+
+assert_line() {
+  local line="$1"
+  local file="$2"
+  grep -Fqx -- "$line" "$file" || {
+    printf 'FAIL: missing line %q in %s\n' "$line" "$file" >&2
+    cat "$file" >&2
+    exit 1
+  }
+}
+
+if "$ROOT/update-helper.sh" "$STATUS" job-direct good fail dirty detached linked 'bad/id'; then
+  printf 'FAIL: a partially failed update job returned success\n' >&2
+  exit 1
+fi
+
+assert_line $'job\tjob-direct' "$STATUS"
+assert_line $'start\tgood' "$STATUS"
+assert_line $'ok\tgood\tupdated good' "$STATUS"
+assert_line $'start\tfail' "$STATUS"
+assert_line $'failed\tfail\tcould not update fail' "$STATUS"
+assert_line $'failed\tdirty\tplugin gained local changes after the update check' "$STATUS"
+assert_line $'failed\tdetached\tplugin is on a detached HEAD' "$STATUS"
+assert_line $'failed\tlinked\tplugin became a symlink after the update check' "$STATUS"
+assert_line $'failed\tbad/id\tinvalid plugin id' "$STATUS"
+assert_line $'done\t1\t5' "$STATUS"
+[[ $(stat -c '%a' "$STATUS") == 600 ]] || {
+  printf 'FAIL: status file mode is %s instead of 600\n' "$(stat -c '%a' "$STATUS")" >&2
+  exit 1
+}
+[[ $(tail -n 1 "$STATUS") == $'done\t1\t5' ]] || {
+  printf 'FAIL: done is not the final status record\n' >&2
+  cat "$STATUS" >&2
+  exit 1
+}
+assert_line 'plugin update good --yes' "$LOG"
+assert_line 'plugin update fail --yes' "$LOG"
+[[ $(wc -l < "$LOG") -eq 2 ]] || {
+  printf 'FAIL: invalid plugin id reached omarchy\n' >&2
+  cat "$LOG" >&2
+  exit 1
+}
+
+# A live runner owns the stable status path. A second runner must fail without
+# replacing or appending to that job's status stream.
+: > "$LOG"
+"$ROOT/update-helper.sh" "$STATUS" job-first slow &
+first_pid=$!
+for _ in {1..100}; do
+  [[ -d $STATUS.lock ]] && break
+  sleep 0.01
+done
+if "$ROOT/update-helper.sh" "$STATUS" job-second good; then
+  printf 'FAIL: a concurrent update runner acquired the same lock\n' >&2
+  exit 1
+else
+  second_rc=$?
+fi
+[[ $second_rc -eq 3 ]] || {
+  printf 'FAIL: concurrent runner returned %s instead of 3\n' "$second_rc" >&2
+  exit 1
+}
+wait "$first_pid"
+assert_line $'job\tjob-first' "$STATUS"
+if grep -Fq $'job\tjob-second' "$STATUS"; then
+  printf 'FAIL: concurrent runner clobbered the active status\n' >&2
+  exit 1
+fi
+
+printf 'update-helper-test: ok\n'

--- a/update-helper.sh
+++ b/update-helper.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Detached update runner for omaplug.
+#
+# The Omarchy shell hot-reloads plugins whenever a checkout changes. Running
+# updates from a tracked QML Process therefore destroys the process owner after
+# the first merge. Quickshell launches this helper detached, and it records
+# progress outside the watched plugin directory so a reloaded panel can
+# reconnect.
+#
+# Usage: update-helper.sh <status-file> <job-id> <plugin-id> [plugin-id ...]
+
+set -uo pipefail
+umask 077
+
+STATUS="${1:-}"
+[[ -n $STATUS ]] || exit 2
+shift
+JOB_ID="${1:-}"
+[[ $JOB_ID =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || exit 2
+shift
+(( $# > 0 )) || exit 2
+
+PLUGINS_DIR="$HOME/.config/omarchy/plugins"
+
+mkdir -p -- "$(dirname -- "$STATUS")"
+LOCK="${STATUS}.lock"
+
+acquire_lock() {
+  if mkdir -- "$LOCK" 2>/dev/null; then
+    return 0
+  fi
+
+  local old_pid=""
+  [[ -r $LOCK/pid ]] && read -r old_pid < "$LOCK/pid"
+  if [[ $old_pid =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+    return 1
+  fi
+
+  rm -rf -- "$LOCK"
+  mkdir -- "$LOCK" 2>/dev/null
+}
+
+acquire_lock || exit 3
+printf '%s\n' "$$" > "$LOCK/pid"
+trap 'rm -rf -- "$LOCK"' EXIT
+
+write_status() {
+  printf '%s\n' "$1" >> "$STATUS"
+}
+
+one_line() {
+  local text="$1"
+  local last
+  last=$(printf '%s\n' "$text" | awk 'NF { line=$0 } END { print line }')
+  last=${last//$'\t'/ }
+  last=${last//$'\r'/ }
+  printf '%.300s' "$last"
+}
+
+preflight_error() {
+  local id="$1"
+  local dir="$PLUGINS_DIR/$id"
+  local changes
+
+  if [[ -L $dir ]]; then
+    printf 'plugin became a symlink after the update check'
+  elif [[ ! -d $dir/.git ]]; then
+    printf 'plugin is no longer a direct git checkout'
+  elif ! git -C "$dir" rev-parse --verify HEAD >/dev/null 2>&1; then
+    printf 'plugin has no commit to update'
+  elif ! git -C "$dir" symbolic-ref --quiet HEAD >/dev/null 2>&1; then
+    printf 'plugin is on a detached HEAD'
+  elif ! changes=$(git -C "$dir" status --porcelain --untracked-files=normal 2>/dev/null); then
+    printf 'could not inspect plugin changes'
+  elif [[ -n $changes ]]; then
+    printf 'plugin gained local changes after the update check'
+  else
+    return 1
+  fi
+}
+
+: > "$STATUS"
+chmod 600 -- "$STATUS" || exit 2
+write_status $'version\t1'
+write_status $'job\t'"$JOB_ID"
+write_status $'pid\t'"$$"
+write_status $'started\t'"$(date +%s)"
+write_status $'total\t'"$#"
+
+updated=0
+failed=0
+
+for id in "$@"; do
+  if [[ ! $id =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ || $id == *..* ]]; then
+    write_status $'failed\t'"$id"$'\tinvalid plugin id'
+    failed=$((failed + 1))
+    continue
+  fi
+
+  if safety_error=$(preflight_error "$id"); then
+    write_status $'failed\t'"$id"$'\t'"$safety_error"
+    failed=$((failed + 1))
+    continue
+  fi
+
+  write_status $'start\t'"$id"
+  out=$(omarchy plugin update "$id" --yes 2>&1)
+  rc=$?
+  detail=$(one_line "$out")
+
+  if (( rc == 0 )); then
+    write_status $'ok\t'"$id"$'\t'"$detail"
+    updated=$((updated + 1))
+  else
+    write_status $'failed\t'"$id"$'\t'"$detail"
+    failed=$((failed + 1))
+  fi
+done
+
+write_status $'finished\t'"$(date +%s)"
+write_status $'done\t'"$updated"$'\t'"$failed"
+(( failed == 0 ))


### PR DESCRIPTION
## What prompted this

While using Omaplug's update flow, I ran into a few related edge cases.

Local development plugins could appear as errors, while installed checkouts containing intentional local changes could repeatedly appear updateable. A genuine update could also remain pending or appear to stop partway through “Update all” when changing a plugin caused Omarchy to reload it.

I also noticed a similar state mismatch with native bar plugins. Removing a widget such as Bluetooth from the bar could leave it displayed as enabled in Omaplug, after which clicking the toggle again appeared to do nothing.

After tracing these behaviors, they seemed to come from three places:

- Repository state was reduced to whether the local and fetched commits differed.
- Update processes were owned by the QML panel that plugin reloads could destroy.
- Native plugin toggles used plugin activity rather than the widget's actual bar placement.

## What changed

### Classify repository state before offering an update

Installed plugins are now classified as:

- `CURRENT`
- `UPDATE`
- `LOCAL_CHANGES`
- `LOCAL`
- `ERROR`

Only clean, directly managed Git checkouts that are genuinely behind their remote are offered an update.

Symlinked development plugins, plain local directories, missing remotes, detached checkouts, dirty worktrees, and locally ahead or diverged repositories remain protected and are presented descriptively rather than treated as ordinary updates.

### Keep “Update all” alive across plugin reloads

Updates now run through a detached helper with progress recorded outside the plugin directory. A reloaded panel can reconnect to the active job instead of losing the process after the first plugin changes.

“Update all” remains sequential intentionally, avoiding competing plugin updates and shell rescans, but one click now completes the entire selected queue.

The worker also includes:

- A final repository safety check immediately before each update
- A lock preventing overlapping update jobs
- Startup acknowledgement and existing-job recovery
- Progress and terminal-state persistence
- Liveness checks for interrupted workers

### Match native toggles to their real bar state

Native bar widgets now use their actual bar placement when displaying and changing toggle state. This keeps Omaplug aligned with what is visible in the bar and allows removed widgets to be enabled again.

Plugins representing the complete bar remain protected from being disabled through the widget toggle.

## Verification

Automated checks:

- `bash -n plugin-state.sh update-helper.sh tests/*.sh`
- `omarchy plugin validate .`
- `./tests/run.sh`

The tests cover repository classification, update preflight safety, locking, sequential completion, interrupted workers, and native Quickshell detached launches.

I also exercised the branch against a real Omarchy session:

- A modified installed checkout remained classified as `Local changes`.
- Development symlinks remained classified as `Local`.
- A genuinely pending plugin completed through the detached worker.
- The shell reloaded while the update was running, but the job reached `done 1 0`.
- The updated plugin subsequently reported `Current`.
- A native Bluetooth widget completed an enabled → disabled → enabled round trip.
- Its original bar placement and shell configuration were restored exactly afterward.