### PR TITLE
fix: avoid non-bindable data reads in icon lookup

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -158,9 +158,12 @@ Panel {
           && (typeof node.slotSize === "number" || typeof node.labelVisible === "boolean")) {
         return node.text
       }
-      var data = node.data
-      if (data) {
-        for (var j = 0; j < data.length; j++) stack.push(data[j])
+      // QObject::data is not bindable; reading it while iconFor() participates
+      // in a Text binding makes Qt warn on every refresh. Bar buttons are
+      // visual items, so the bindable visual-child tree is the right scope.
+      var children = node.children
+      if (children) {
+        for (var j = 0; j < children.length; j++) stack.push(children[j])
       }
     }
     return ""


### PR DESCRIPTION
## Summary
- walk the bindable visual `children` tree when discovering live widget glyphs
- avoid reading non-bindable `QObject::data` from a QML text binding
- stop repeated `QQmlExpression ... depends on non-bindable properties` warnings

## Verification
- restarted Omarchy Shell with the patched live plugin
- confirmed the new shell process loads omaplug without the warning
- `git diff --check` passes