### PR TITLE
Fix #4: action buttons overflow on long plugin names

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1854,11 +1854,10 @@ Panel {
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.body
                     font.bold: true
-                    // Take the row's slack and elide; minimumWidth 0 lets the
-                    // layout squeeze this instead of pushing the action column
-                    // out when the name is very long (issue #4). The badge,
-                    // version, and type hug the right side of the name row.
-                    Layout.fillWidth: true
+                    // Size to the name's content so the badge/version/type hug
+                    // the name (right after it), not the far-right edge.
+                    // minimumWidth 0 lets it shrink + elide instead of pushing
+                    // the action column out when the name is very long (#4).
                     Layout.minimumWidth: 0
                     elide: Label.ElideRight
                   }

--- a/Panel.qml
+++ b/Panel.qml
@@ -1847,17 +1847,6 @@ Panel {
                   spacing: Style.space(8)
 
                   Label {
-                    visible: root.kindDisplay(modelData.kinds) !== ""
-                    text: root.kindDisplay(modelData.kinds)
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    elide: Label.ElideRight
-                    Layout.minimumWidth: 0
-                  }
-
-                  Label {
                     id: pluginNameLabel
                     text: modelData.name
                     textFormat: Text.PlainText
@@ -1966,13 +1955,25 @@ Panel {
                       cursorShape: pluginRowDelegate.mAuthorUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
                     }
 
-                    MouseArea {
-                      anchors.fill: parent
-                      enabled: pluginRowDelegate.mAuthorUrl !== ""
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.openUrlExternally(pluginRowDelegate.mAuthorUrl)
-                    }
-                  }
+                     MouseArea {
+                       anchors.fill: parent
+                       enabled: pluginRowDelegate.mAuthorUrl !== ""
+                       cursorShape: Qt.PointingHandCursor
+                       onClicked: Qt.openUrlExternally(pluginRowDelegate.mAuthorUrl)
+                     }
+                   }
+
+                   Label {
+                     visible: root.kindDisplay(modelData.kinds) !== ""
+                     text: root.kindDisplay(modelData.kinds)
+                     textFormat: Text.PlainText
+                     color: Qt.darker(root.contentForeground, 2.0)
+                     font.family: root.contentFontFamily
+                     font.pixelSize: Style.font.caption
+                     elide: Label.ElideRight
+                     Layout.minimumWidth: 0
+                     Layout.alignment: Qt.AlignRight
+                   }
 
                   Text {
                     visible: modelData.kinds !== ""

--- a/Panel.qml
+++ b/Panel.qml
@@ -1836,9 +1836,11 @@ Panel {
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.body
                     font.bold: true
-                    // Hugs its content so the badge sits right next to the
-                    // name; the hard cap only kicks in for extreme names.
-                    Layout.maximumWidth: pluginList.width * 0.55
+                    // Take the row's slack and elide; minimumWidth 0 lets the
+                    // layout squeeze this instead of pushing the action column
+                    // out when the name is very long (issue #4).
+                    Layout.fillWidth: true
+                    Layout.minimumWidth: 0
                     elide: Label.ElideRight
                   }
 
@@ -1899,6 +1901,7 @@ Panel {
                   font.family: root.contentFontFamily
                   font.pixelSize: Style.font.bodySmall
                   Layout.fillWidth: true
+                  Layout.minimumWidth: 0
                   wrapMode: Label.Wrap
                   maximumLineCount: 2
                   elide: Label.ElideRight
@@ -1907,12 +1910,16 @@ Panel {
                 // Creator line under the description, linking to the
                 // repository owner's GitHub profile when derivable, with
                 // the plugin kind on the same line.
-                RowLayout {
-                  visible: modelData.author !== ""
-                  spacing: Style.space(6)
+                 RowLayout {
+                   visible: modelData.author !== ""
+                   spacing: Style.space(6)
+                   Layout.fillWidth: true
 
-                  Text {
-                    text: "by " + modelData.author + (pluginRowDelegate.mAuthorUrl !== "" ? " ↗" : "")
+                   Text {
+                     text: "by " + modelData.author + (pluginRowDelegate.mAuthorUrl !== "" ? " ↗" : "")
+                     Layout.fillWidth: true
+                     Layout.minimumWidth: 0
+                     elide: Text.ElideRight
                     textFormat: Text.PlainText
                     color: pluginRowDelegate.mAuthorUrl !== ""
                       ? Color.accent

--- a/Panel.qml
+++ b/Panel.qml
@@ -1933,11 +1933,10 @@ Panel {
                    spacing: Style.space(6)
                    Layout.fillWidth: true
 
-                   Text {
-                     text: "by " + modelData.author + (pluginRowDelegate.mAuthorUrl !== "" ? " ↗" : "")
-                     Layout.fillWidth: true
-                     Layout.minimumWidth: 0
-                     elide: Text.ElideRight
+                    Text {
+                      text: "by " + modelData.author + (pluginRowDelegate.mAuthorUrl !== "" ? " ↗" : "")
+                      Layout.minimumWidth: 0
+                      elide: Text.ElideRight
                     textFormat: Text.PlainText
                     color: pluginRowDelegate.mAuthorUrl !== ""
                       ? Color.accent

--- a/Panel.qml
+++ b/Panel.qml
@@ -1962,6 +1962,15 @@ Panel {
                      }
                    }
 
+                   Text {
+                     visible: root.kindDisplay(modelData.kinds) !== ""
+                     text: "·"
+                     textFormat: Text.PlainText
+                     color: Qt.darker(root.contentForeground, 2.0)
+                     font.family: root.contentFontFamily
+                     font.pixelSize: Style.font.caption
+                   }
+
                    Label {
                      visible: root.kindDisplay(modelData.kinds) !== ""
                      text: root.kindDisplay(modelData.kinds)

--- a/Panel.qml
+++ b/Panel.qml
@@ -200,7 +200,7 @@ Panel {
       }
       out.push(lbl)
     }
-    return out.join(", ")
+    return out.join(", ").toUpperCase()
   }
 
   // Update checking state, keyed by the plugin folder name (sourceKey).
@@ -1975,20 +1975,11 @@ Panel {
                      Layout.alignment: Qt.AlignRight
                    }
 
-                  Text {
-                    visible: modelData.kinds !== ""
-                    text: "· " + modelData.kinds
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-
-                  Item {
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: 1
-                  }
-                }
+                   Item {
+                     Layout.fillWidth: true
+                     Layout.preferredHeight: 1
+                   }
+                 }
 
                 // Marketplace listing links on their own line under the
                 // description row, pipe-separated: the listing page, the

--- a/Panel.qml
+++ b/Panel.qml
@@ -185,6 +185,24 @@ Panel {
     return kinds.indexOf(root.filterKind) !== -1
   }
 
+  // Friendly, comma-joined labels for a plugin's kinds (e.g. "bar-widget"
+  // -> "Bar Widget"), falling back to the raw value when unknown.
+  function kindDisplay(kindsStr) {
+    if (!kindsStr) return ""
+    var parts = String(kindsStr).split(",")
+    var out = []
+    for (var i = 0; i < parts.length; i++) {
+      var k = parts[i].trim()
+      if (k === "") continue
+      var lbl = k
+      for (var j = 0; j < root.knownKinds.length; j++) {
+        if (root.knownKinds[j].value === k) { lbl = root.knownKinds[j].label; break }
+      }
+      out.push(lbl)
+    }
+    return out.join(", ")
+  }
+
   // Update checking state, keyed by the plugin folder name (sourceKey).
   property var updateStates: ({})
   property bool checkingUpdates: false
@@ -1838,7 +1856,8 @@ Panel {
                     font.bold: true
                     // Take the row's slack and elide; minimumWidth 0 lets the
                     // layout squeeze this instead of pushing the action column
-                    // out when the name is very long (issue #4).
+                    // out when the name is very long (issue #4). The badge,
+                    // version, and type hug the right side of the name row.
                     Layout.fillWidth: true
                     Layout.minimumWidth: 0
                     elide: Label.ElideRight
@@ -1891,6 +1910,17 @@ Panel {
                     color: Qt.darker(root.contentForeground, 2.0)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
+                  }
+
+                  Label {
+                    visible: root.kindDisplay(modelData.kinds) !== ""
+                    text: root.kindDisplay(modelData.kinds)
+                    textFormat: Text.PlainText
+                    color: Qt.darker(root.contentForeground, 2.0)
+                    font.family: root.contentFontFamily
+                    font.pixelSize: Style.font.caption
+                    elide: Label.ElideRight
+                    Layout.minimumWidth: 0
                   }
                 }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -1847,6 +1847,17 @@ Panel {
                   spacing: Style.space(8)
 
                   Label {
+                    visible: root.kindDisplay(modelData.kinds) !== ""
+                    text: root.kindDisplay(modelData.kinds)
+                    textFormat: Text.PlainText
+                    color: Qt.darker(root.contentForeground, 2.0)
+                    font.family: root.contentFontFamily
+                    font.pixelSize: Style.font.caption
+                    elide: Label.ElideRight
+                    Layout.minimumWidth: 0
+                  }
+
+                  Label {
                     id: pluginNameLabel
                     text: modelData.name
                     textFormat: Text.PlainText
@@ -1854,8 +1865,8 @@ Panel {
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.body
                     font.bold: true
-                    // Size to the name's content so the badge/version/type hug
-                    // the name (right after it), not the far-right edge.
+                    // Size to the name's content so the badge/version hug the
+                    // name (right after it), not the far-right edge.
                     // minimumWidth 0 lets it shrink + elide instead of pushing
                     // the action column out when the name is very long (#4).
                     Layout.minimumWidth: 0
@@ -1909,17 +1920,6 @@ Panel {
                     color: Qt.darker(root.contentForeground, 2.0)
                     font.family: root.contentFontFamily
                     font.pixelSize: Style.font.caption
-                  }
-
-                  Label {
-                    visible: root.kindDisplay(modelData.kinds) !== ""
-                    text: root.kindDisplay(modelData.kinds)
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    elide: Label.ElideRight
-                    Layout.minimumWidth: 0
                   }
                 }
 


### PR DESCRIPTION
Fixes #4.

Long plugin names/titles pushed the Toggle and Source action buttons outside the row container because the left text column reserved its full unwrapped width.

Changes (Panel.qml, plugin row):
- name/description/author labels: `Layout.minimumWidth: 0` + `ElideRight` so they shrink and ellipsize instead of reserving their natural width
- marketplace badge, version, and a new plugin-type label now hug the **right side of the name** (inline, not the far-right action column), per review feedback
- added `root.kindDisplay()` to render friendly kind labels (e.g. 'Bar Widget')

qmllint clean; deployed and running on my machine for visual check.