### PR TITLE
refactor(panel): split views into focused components

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -1,7 +1,5 @@
 import QtQuick
-import Quickshell
 import Quickshell.Io
-import qs.Commons
 import qs.Ui
 
 BarWidget {

--- a/Panel.qml
+++ b/Panel.qml
@@ -8,6 +8,7 @@ import Quickshell.Io
 import qs.Commons
 import qs.Ui
 import "panel/Presentation.js" as Presentation
+import "panel/dialogs" as Dialogs
 import "panel/plugin" as Plugin
 import "panel/updates" as Updates
 
@@ -183,8 +184,8 @@ Panel {
   property bool installRunning: false
   property bool installFailed: false
   property string installResult: ""
-  // Confirm popup shown before running install: ask whether to enable the
-  // freshly installed plugin. installPendingUrl carries the extracted URL.
+  // Confirm popup shown before running install: makes the disabled-by-default
+  // policy explicit. installPendingUrl carries the extracted URL.
   property bool installConfirmOpen: false
   property string installPendingUrl: ""
   // Status file for the detached installer. The file is created securely
@@ -216,7 +217,6 @@ Panel {
       root.installRunning = false
       root.installFailed = false
       root.installResult = ""
-      Qt.callLater(function() { installUrlField.forceActiveFocus() })
     } else {
       root.installConfirmOpen = false
       root.installPendingUrl = ""
@@ -1026,19 +1026,13 @@ Panel {
     return ""
   }
 
-  // `--enable` in a pasted command is honored: the plugin is enabled after
-  // install, matching `omarchy plugin add <url> --enable`.
-  function installCommandHasEnable(text) {
-    return /\s--enable\b/.test(" " + String(text || "").trim())
-  }
-
   // Called from the install dialog: extract the URL and ask for
   // confirmation. Only GitHub URLs are accepted (https://github.com/owner/repo
   // or git@github.com:owner/repo.git), matching omarchy plugin/theme
   // expectations and preventing arbitrary host installs. The plugin is
   // installed but NOT enabled by default.
-  function requestInstall() {
-    var raw = String(installUrlField.text || "").trim()
+  function requestInstall(rawText) {
+    var raw = String(rawText || "").trim()
     if (raw === "") return
     var url = root.extractInstallUrl(raw)
     if (url === "") {
@@ -1064,7 +1058,7 @@ Panel {
 
   // Launch the detached helper. `omarchy plugin add` reloads plugins when it
   // finishes, which unloads this panel; the helper is started with
-  // setsid/nohup so it survives and finishes the enable itself.
+  // setsid/nohup so it survives and finishes the installation itself.
   // The status file is created securely via mktemp to avoid predictable /tmp
   // symlink races (the helper truncates it, so creation must be exclusive).
   property string _installPendingUrl: ""
@@ -1806,378 +1800,81 @@ Panel {
       onRemovalRequested: function(pluginId) { root.removePlugin(pluginId) }
     }
 
-    // Confirmation before any plugin removal. Shows what is about to be deleted
-    // (single plugin or a multi-selection count) with a Remove / Cancel choice.
-    Rectangle {
-      id: removeConfirmDialog
-      visible: root.removeConfirmOpen
+    Dialogs.Confirm {
       anchors.fill: parent
       z: 7000
-      color: Util.alpha(root.panelBackground, 0.7)
-      focus: true
-      Keys.priority: Keys.BeforeItem
-      Keys.onEscapePressed: {
-        if (!root.removingPlugin) root.removeConfirmOpen = false
-      }
 
-      MouseArea {
-        anchors.fill: parent
-        onClicked: {
-          if (!root.removingPlugin) root.removeConfirmOpen = false
-        }
-      }
+      open: root.removeConfirmOpen
+      title: root.removePending.length > 1
+        ? "Remove " + root.removePending.length + " plugins?"
+        : "Remove this plugin?"
+      message: root.removePending.length > 1
+        ? "The selected plugins will be deleted from your config. This cannot be undone."
+        : "\"" + (root.removePending.length === 1 ? root.removePending[0] : "") + "\" will be deleted from your config. This cannot be undone."
+      confirmText: "Remove"
+      dismissEnabled: !root.removingPlugin
+      borderColor: Color.urgent
+      confirmForeground: Color.urgent
+      confirmAccent: Color.urgent
+      confirmBordered: true
+      titleWrapMode: Text.WordWrap
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
 
-      Rectangle {
-        id: removeConfirmCard
-        anchors.centerIn: parent
-        width: Math.min(parent.width - Style.space(32), Style.space(360))
-        height: removeConfirmColumn.implicitHeight + Style.space(36)
-        color: root.panelBackground
-        radius: Style.cornerRadius
-        border.color: Color.urgent
-        border.width: 1
-
-        ColumnLayout {
-          id: removeConfirmColumn
-          anchors.fill: parent
-          anchors.margins: Style.space(18)
-          spacing: Style.space(12)
-
-          Text {
-            text: root.removePending.length > 1
-              ? "Remove " + root.removePending.length + " plugins?"
-              : "Remove this plugin?"
-            color: root.contentForeground
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.title
-            font.bold: true
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          Text {
-            text: root.removePending.length > 1
-              ? "The selected plugins will be deleted from your config. This cannot be undone."
-              : "\"" + (root.removePending.length === 1 ? root.removePending[0] : "") + "\" will be deleted from your config. This cannot be undone."
-            textFormat: Text.PlainText
-            color: Qt.darker(root.contentForeground, 1.6)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          RowLayout {
-            Layout.fillWidth: true
-
-            Item { Layout.fillWidth: true }
-
-            Button {
-              text: "Cancel"
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.cancelRemove()
-            }
-
-            Button {
-              text: "Remove"
-              bordered: true
-              foreground: Color.urgent
-              accent: Color.urgent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.confirmRemove()
-            }
-          }
-        }
-      }
+      onCancelRequested: root.cancelRemove()
+      onConfirmRequested: root.confirmRemove()
     }
 
-    // Confirmation before restarting the shell. Warns that the shell (and this
-    // panel) will briefly disappear while plugins reload from source.
-    Rectangle {
-      id: restartConfirmDialog
-      visible: root.restartConfirmOpen
+    Dialogs.Confirm {
       anchors.fill: parent
       z: 7000
-      color: Util.alpha(root.panelBackground, 0.7)
-      focus: true
-      Keys.priority: Keys.BeforeItem
-      Keys.onEscapePressed: root.cancelRestartShell()
 
-      MouseArea {
-        anchors.fill: parent
-        onClicked: root.cancelRestartShell()
-      }
+      open: root.restartConfirmOpen
+      title: "Restart the shell?"
+      message: "The shell (and this panel) will restart so every plugin reloads from source. This fixes plugins that still run stale compiled QML. Unsaved panel state will be lost."
+      confirmText: "Restart"
+      confirmBordered: true
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
 
-      Rectangle {
-        id: restartConfirmCard
-        anchors.centerIn: parent
-        width: Math.min(parent.width - Style.space(32), Style.space(360))
-        height: restartConfirmColumn.implicitHeight + Style.space(36)
-        color: root.panelBackground
-        radius: Style.cornerRadius
-        border.color: Style.selectedStateColor(root.contentForeground, Color.accent)
-        border.width: 1
-
-        ColumnLayout {
-          id: restartConfirmColumn
-          anchors.fill: parent
-          anchors.margins: Style.space(18)
-          spacing: Style.space(12)
-
-          Text {
-            text: "Restart the shell?"
-            color: root.contentForeground
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.title
-            font.bold: true
-            Layout.fillWidth: true
-          }
-
-          Text {
-            text: "The shell (and this panel) will restart so every plugin reloads from source. This fixes plugins that still run stale compiled QML. Unsaved panel state will be lost."
-            color: Qt.darker(root.contentForeground, 1.6)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          RowLayout {
-            Layout.fillWidth: true
-
-            Item { Layout.fillWidth: true }
-
-            Button {
-              text: "Cancel"
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.cancelRestartShell()
-            }
-
-            Button {
-              text: "Restart"
-              bordered: true
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.confirmRestartShell()
-            }
-          }
-        }
-      }
+      onCancelRequested: root.cancelRestartShell()
+      onConfirmRequested: root.confirmRestartShell()
     }
 
-    Rectangle {
-      id: installDialog
-      visible: root.installDialogOpen
+    Dialogs.Install {
       anchors.fill: parent
       z: 10000
-      color: Util.alpha(root.panelBackground, 0.7)
-      focus: true
-      Keys.priority: Keys.BeforeItem
-      Keys.onEscapePressed: {
-        if (!root.installRunning) root.installDialogOpen = false
-      }
 
-      MouseArea {
-        anchors.fill: parent
-        onClicked: {
-          if (!root.installRunning) root.installDialogOpen = false
-        }
-      }
+      open: root.installDialogOpen
+      running: root.installRunning
+      failed: root.installFailed
+      result: root.installResult
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
 
-      Rectangle {
-        id: installCard
-        anchors.centerIn: parent
-        width: Math.min(parent.width - Style.space(32), Style.space(360))
-        height: installColumn.implicitHeight + Style.space(36)
-        color: root.panelBackground
-        radius: Style.cornerRadius
-        border.color: Style.selectedStateColor(root.contentForeground, Color.accent)
-        border.width: 1
-
-        ColumnLayout {
-          id: installColumn
-          anchors.fill: parent
-          anchors.margins: Style.space(18)
-          spacing: Style.space(12)
-
-          Text {
-            text: "Install a plugin from a git repo"
-            color: root.contentForeground
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.title
-            font.bold: true
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          Text {
-            text: "Plugins run as arbitrary, unsandboxed code inside your omarchy-shell process. Only add repos you trust — review the code before you enable the plugin."
-            color: Qt.darker(root.contentForeground, 1.6)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          TextField {
-            id: installUrlField
-            placeholderText: "https://github.com/acme/omarchy-weather.git"
-            foreground: root.contentForeground
-            accent: Color.accent
-            font.family: root.contentFontFamily
-            Layout.fillWidth: true
-            onAccepted: {
-              if (installUrlField.text.trim() !== "" && !root.installRunning)
-                root.requestInstall()
-            }
-          }
-
-          Text {
-            visible: root.installResult !== ""
-            text: root.installResult
-            textFormat: Text.PlainText
-            color: root.installRunning ? root.contentForeground
-              : (root.installFailed ? Color.urgent
-                : Style.selectedStateColor(root.contentForeground, Color.accent))
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.caption
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          RowLayout {
-            Layout.fillWidth: true
-
-            Item { Layout.fillWidth: true }
-
-            Button {
-              text: root.installResult !== "" ? "Close" : "Cancel"
-              enabled: !root.installRunning
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.installDialogOpen = false
-            }
-
-            Button {
-              text: root.installRunning ? "Installing…" : "Install"
-              enabled: !root.installRunning
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.requestInstall()
-            }
-          }
-        }
-      }
+      onCloseRequested: root.installDialogOpen = false
+      onInstallRequested: function(rawUrl) { root.requestInstall(rawUrl) }
     }
 
-    // Confirmation before installing: ask whether to enable the freshly
-    // installed plugin. Shown above the install dialog so the entered URL
-    // stays visible while deciding.
-    Rectangle {
-      id: installConfirmDialog
-      visible: root.installConfirmOpen
+    Dialogs.Confirm {
       anchors.fill: parent
       z: 11000
-      color: Util.alpha(root.panelBackground, 0.7)
-      focus: true
-      Keys.priority: Keys.BeforeItem
-      Keys.onEscapePressed: root.cancelInstallConfirm()
 
-      MouseArea {
-        anchors.fill: parent
-        onClicked: root.cancelInstallConfirm()
-      }
+      open: root.installConfirmOpen
+      title: "Install plugin?"
+      message: "\"" + root.installPendingUrl + "\" will be added via `omarchy plugin add` but will remain DISABLED until you enable it manually. Review the code after install, then enable from the plugin list."
+      confirmText: "Install"
+      maximumWidth: Style.space(380)
+      titleWrapMode: Text.WordWrap
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
 
-      Rectangle {
-        id: installConfirmCard
-        anchors.centerIn: parent
-        width: Math.min(parent.width - Style.space(32), Style.space(380))
-        height: installConfirmColumn.implicitHeight + Style.space(36)
-        color: root.panelBackground
-        radius: Style.cornerRadius
-        border.color: Style.selectedStateColor(root.contentForeground, Color.accent)
-        border.width: 1
-
-        ColumnLayout {
-          id: installConfirmColumn
-          anchors.fill: parent
-          anchors.margins: Style.space(18)
-          spacing: Style.space(12)
-
-          Text {
-            text: "Install plugin?"
-            color: root.contentForeground
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.title
-            font.bold: true
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          Text {
-            text: "\"" + root.installPendingUrl + "\" will be added via `omarchy plugin add` but will remain DISABLED until you enable it manually. Review the code after install, then enable from the plugin list."
-            textFormat: Text.PlainText
-            color: Qt.darker(root.contentForeground, 1.6)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-            Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-          }
-
-          RowLayout {
-            Layout.fillWidth: true
-
-            Item { Layout.fillWidth: true }
-
-            Button {
-              text: "Cancel"
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.cancelInstallConfirm()
-            }
-
-            Button {
-              text: "Install"
-              foreground: root.contentForeground
-              accent: Color.accent
-              fontFamily: root.contentFontFamily
-              fontSize: Style.font.bodySmall
-              horizontalPadding: Style.space(12)
-              verticalPadding: Style.space(6)
-              onClicked: root.installPlugin()
-            }
-          }
-        }
-      }
+      onCancelRequested: root.cancelInstallConfirm()
+      onConfirmRequested: root.installPlugin()
     }
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -1782,103 +1782,28 @@ Panel {
     }
 
 
-    // ── Row context menu ─────────────────────────────────────────────────────
-    // Right-click on a plugin row on the main page opens a small menu with the
-    // same actions the row buttons offer: enable/disable, open the source repo
-    // (when known), and remove. Implemented as an overlay Rectangle (matching
-    // the other dialogs) instead of a QQC Popup.
-    Rectangle {
+    Plugin.ContextMenu {
       id: rowMenuOverlay
-      visible: root.rowMenuOpen
       anchors.fill: parent
       z: 12000
-      color: "transparent"
-      focus: true
-      Keys.priority: Keys.BeforeItem
-      Keys.onEscapePressed: root.closeRowMenu()
 
-      MouseArea {
-        anchors.fill: parent
-        onClicked: root.closeRowMenu()
+      open: root.rowMenuOpen
+      plugin: root.rowMenuPlugin()
+      pluginEnabled: rowMenuOverlay.plugin ? root.pluginEnabled(rowMenuOverlay.plugin.id) : false
+      repoKnown: rowMenuOverlay.plugin
+        && rowMenuOverlay.plugin.sourceKey !== ""
+        && root.pluginRepos[rowMenuOverlay.plugin.sourceKey] !== undefined
+      requestedPosition: root.rowMenuPos
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
+
+      onCloseRequested: root.closeRowMenu()
+      onEnabledChangeRequested: function(pluginId, enabled) {
+        root.setPluginEnabled(pluginId, enabled)
       }
-
-      Rectangle {
-        id: rowMenu
-        x: Math.min(root.rowMenuPos.x, parent.width - width - Style.space(4))
-        y: Math.min(root.rowMenuPos.y, parent.height - height - Style.space(4))
-        width: rowMenuColumn.implicitWidth + Style.space(8)
-        height: rowMenuColumn.implicitHeight + Style.space(8)
-        color: root.panelBackground
-        radius: Style.cornerRadius
-        border.color: Util.alpha(root.contentForeground, 0.2)
-        border.width: 1
-
-        ColumnLayout {
-          id: rowMenuColumn
-          anchors.fill: parent
-          anchors.margins: Style.space(4)
-          spacing: Style.space(2)
-          implicitWidth: Style.space(180)
-
-          property var plugin: root.rowMenuPlugin()
-          readonly property bool pluginIsEnabled: plugin ? root.pluginEnabled(plugin.id) : false
-
-          Button {
-            text: rowMenuColumn.pluginIsEnabled
-              ? (rowMenuColumn.plugin.canDisable ? "Disable" : "Active bar")
-              : "Enable"
-            enabled: rowMenuColumn.plugin
-              && (rowMenuColumn.plugin.canDisable || !rowMenuColumn.pluginIsEnabled)
-            foreground: root.contentForeground
-            accent: Color.accent
-            fontFamily: root.contentFontFamily
-            fontSize: Style.font.bodySmall
-            horizontalPadding: Style.space(8)
-            verticalPadding: Style.space(5)
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignLeft
-            onClicked: {
-              root.setPluginEnabled(root.rowMenuId, !rowMenuColumn.pluginIsEnabled)
-              root.closeRowMenu()
-            }
-          }
-
-          Button {
-            visible: rowMenuColumn.plugin && rowMenuColumn.plugin.sourceKey !== "" && root.pluginRepos[rowMenuColumn.plugin.sourceKey] !== undefined
-            text: "Source"
-            foreground: root.contentForeground
-            accent: Color.accent
-            fontFamily: root.contentFontFamily
-            fontSize: Style.font.bodySmall
-            horizontalPadding: Style.space(8)
-            verticalPadding: Style.space(5)
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignLeft
-            onClicked: {
-              root.openPluginRepo(rowMenuColumn.plugin.sourceKey)
-              root.closeRowMenu()
-            }
-          }
-
-          Button {
-            visible: rowMenuColumn.plugin && !rowMenuColumn.plugin.firstParty
-            text: "Remove"
-            foreground: Color.urgent
-            accent: Color.urgent
-            fontFamily: root.contentFontFamily
-            fontSize: Style.font.bodySmall
-            horizontalPadding: Style.space(8)
-            verticalPadding: Style.space(5)
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignLeft
-            onClicked: {
-              var id = root.rowMenuId
-              root.closeRowMenu()
-              root.removePlugin(id)
-            }
-          }
-        }
-      }
+      onSourceRequested: function(sourceKey) { root.openPluginRepo(sourceKey) }
+      onRemovalRequested: function(pluginId) { root.removePlugin(pluginId) }
     }
 
     // Confirmation before any plugin removal. Shows what is about to be deleted

--- a/Panel.qml
+++ b/Panel.qml
@@ -7,6 +7,7 @@ import Quickshell.Io
 import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
+import "panel/updates" as Updates
 
 // Plugin manager popup: lists every discovered plugin (first-party omarchy +
 // third-party) with an enable/disable switch. The list is read from the
@@ -432,27 +433,6 @@ Panel {
   readonly property var updateCheckRows: root.pluginRows.filter(function(p) {
     return p.updatable && root.pluginRepos[String(p.sourceKey)] !== undefined
   })
-
-  function updateStatusText(key) {
-    var st = root.updateStates[key]
-    if (!st) return "Pending"
-    if (st === "CHECK") return "Checking…"
-    if (st === "CURRENT") return "Up to date"
-    if (st === "UPDATE") return "Update available"
-    if (st === "LOCAL_CHANGES") return "Local changes"
-    if (st === "LOCAL") return "Local plugin"
-    if (st === "ERROR") return "Error"
-    return st
-  }
-
-  function updateStatusColor(key) {
-    var st = root.updateStates[key]
-    if (st === "UPDATE") return Style.selectedStateColor(root.contentForeground, Color.accent)
-    if (st === "ERROR") return Color.urgent
-    if (st === "CURRENT") return Qt.darker(root.contentForeground, 1.6)
-    if (st === "LOCAL_CHANGES" || st === "LOCAL") return Qt.darker(root.contentForeground, 1.5)
-    return Qt.darker(root.contentForeground, 1.4)
-  }
 
   function updateErrorSuffix(count) {
     return count > 0 ? " (" + count + " error" + (count === 1 ? "" : "s") + ")" : ""
@@ -1659,7 +1639,6 @@ Panel {
             verticalPadding: Style.space(5)
             onClicked: {
               root.updatesPageOpen = true
-              updatesPageLoader.stayLoaded = true
               if (!root.checkingUpdates) root.checkUpdates()
             }
           }
@@ -2424,335 +2403,32 @@ Panel {
         }
       }
     }
-    // Full-page view shown when the user asks to check for updates. Lists the
-    // git-managed plugins with live per-plugin status (streamed from the check
-    // process), a running progress bar while checking, and an Update all button
-    // pinned to the bottom.
-    Rectangle {
+    Updates.Page {
       id: updatesPage
-      visible: root.updatesPageOpen
       anchors.fill: parent
       z: 5000
-      color: root.panelBackground
 
-      // Contents are heavy (full second list). Instantiate lazily the first
-      // time the user opens this page; afterwards they stay alive.
-      Loader {
-        id: updatesPageLoader
-        anchors.fill: parent
-        // stayLoaded keeps contents alive after first open
-        property bool stayLoaded: false
-        active: root.updatesPageOpen || stayLoaded
-        sourceComponent: updatesPageComponent
-      }
+      open: root.updatesPageOpen
+      topInset: appHeader.height + Style.space(16)
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
+      rows: root.updateCheckRows
+      updateStates: root.updateStates
+      checking: root.checkingUpdates
+      updateRunning: root.updateDetachedRunning
+      updatingAll: root.updatingAll
+      pendingCount: root.pendingUpdateCount
+      summary: root.updateSummary
+      iconFor: root.iconFor
+      iconColorFor: root.iconColorFor
+      whatsNewUrlFor: root.whatsNewUrlFor
 
-      Component {
-        id: updatesPageComponent
-        Item {
-          anchors.fill: parent
-
-      PanelKeyCatcher {
-        anchors.fill: parent
-        onCloseRequested: root.updatesPageOpen = false
-        onTabRequested: function(direction) { root.switchPanel(direction) }
-      }
-
-      ColumnLayout {
-        anchors.fill: parent
-        anchors.margins: Style.space(16)
-        anchors.topMargin: appHeader.height + Style.space(16)
-        spacing: Style.space(10)
-
-        RowLayout {
-          Layout.fillWidth: true
-          spacing: Style.space(8)
-
-          Label {
-            text: "Check for updates"
-            color: root.contentForeground
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.body
-            font.bold: true
-            Layout.fillWidth: true
-          }
-
-          Button {
-            text: "Back"
-            foreground: root.contentForeground
-            accent: Color.accent
-            fontFamily: root.contentFontFamily
-            fontSize: Style.font.bodySmall
-            horizontalPadding: Style.space(10)
-            verticalPadding: Style.space(5)
-            onClicked: root.updatesPageOpen = false
-          }
-        }
-
-        Rectangle {
-          id: checkProgress
-          visible: root.checkingUpdates
-          Layout.fillWidth: true
-          Layout.preferredHeight: 3
-          radius: 1.5
-          color: Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.15)
-          clip: true
-
-          Rectangle {
-            id: checkProgressChunk
-            width: checkProgress.width * 0.4
-            height: checkProgress.height
-            radius: checkProgress.radius
-            color: Style.selectedStateColor(root.contentForeground, Color.accent)
-
-            NumberAnimation on x {
-              running: root.checkingUpdates
-              loops: Animation.Infinite
-              from: -width
-              to: checkProgress.width
-              duration: 1100
-              easing.type: Easing.InOutQuad
-            }
-          }
-        }
-
-        ListView {
-          id: updateList
-          Layout.fillWidth: true
-          Layout.fillHeight: true
-          clip: true
-          spacing: Style.space(4)
-          model: root.updateCheckRows
-          ScrollBar.vertical: ScrollBar {
-            policy: ScrollBar.AsNeeded
-            implicitWidth: Style.space(6)
-            contentItem: Rectangle {
-              implicitWidth: Style.space(6)
-              implicitHeight: Style.space(6)
-              radius: width / 2
-              color: Util.alpha(root.contentForeground, 0.45)
-            }
-          }
-
-          delegate: Rectangle {
-            required property var modelData
-            width: updateList.width
-            height: Math.max(Style.space(52), row.implicitHeight + Style.space(16))
-            radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
-            color: hover.hovered
-              ? Style.hoverFillFor(root.contentForeground, Color.accent)
-              : "transparent"
-
-            RowLayout {
-              id: row
-              anchors.fill: parent
-              anchors.leftMargin: Style.space(10)
-              anchors.topMargin: Style.space(8)
-              anchors.rightMargin: Style.space(10)
-              anchors.bottomMargin: Style.space(12)
-              spacing: Style.space(10)
-
-              Rectangle {
-                id: updateIcon
-                width: Style.space(28)
-                height: width
-                radius: 6
-                color: root.iconColorFor(modelData.name)
-
-                Text {
-                  anchors.centerIn: parent
-                  text: root.iconFor(modelData.id) || modelData.name.trim().charAt(0).toUpperCase()
-                  textFormat: Text.PlainText
-                  color: "white"
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.bodySmall
-                  font.bold: true
-                }
-              }
-
-              ColumnLayout {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                spacing: Style.space(2)
-
-                Label {
-                  text: modelData.name
-                  textFormat: Text.PlainText
-                  color: root.contentForeground
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.body
-                  font.bold: true
-                  Layout.fillWidth: true
-                  elide: Label.ElideRight
-                }
-
-                Label {
-                  text: root.updateStatusText(modelData.sourceKey)
-                  textFormat: Text.PlainText
-                  color: root.updateStatusColor(modelData.sourceKey)
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.caption
-                }
-
-                Text {
-                  id: whatsNewLink
-                  readonly property string wnUrl: root.whatsNewUrlFor(modelData.sourceKey, modelData.id)
-                  visible: root.updateStates[String(modelData.sourceKey)] === "UPDATE" && wnUrl !== ""
-                  text: "What's new ↗"
-                  textFormat: Text.PlainText
-                  color: Color.accent
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.caption
-                  font.underline: whatsNewLinkHover.hovered
-                  ToolTip.text: wnUrl
-                  ToolTip.visible: whatsNewLinkHover.hovered
-                  ToolTip.delay: 400
-
-                  HoverHandler {
-                    id: whatsNewLinkHover
-                    cursorShape: Qt.PointingHandCursor
-                  }
-
-                  MouseArea {
-                    anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.openExternal(whatsNewLink.wnUrl)
-                  }
-                }
-              }
-
-              // Per-plugin check status: a ring spinner while the fetch for this
-              // plugin is still running, a check icon once it finished (whether
-              // current, update available, or errored).
-              Item {
-                id: checkRing
-                visible: root.updateStates[modelData.sourceKey] === "CHECK"
-                  || root.updateStates[modelData.sourceKey] === undefined
-                Layout.alignment: Qt.AlignVCenter
-                width: Style.space(18)
-                height: Style.space(18)
-
-                Rectangle {
-                  anchors.fill: parent
-                  radius: width / 2
-                  color: "transparent"
-                  border.width: 2
-                  border.color: Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.18)
-                }
-
-                Item {
-                  id: checkRingArc
-                  anchors.fill: parent
-                  visible: root.updateStates[modelData.sourceKey] === "CHECK"
-                    || root.updateStates[modelData.sourceKey] === undefined
-
-                  RotationAnimation on rotation {
-                    running: checkRingArc.visible
-                    loops: Animation.Infinite
-                    from: 0
-                    to: 360
-                    duration: 900
-                  }
-
-                  Canvas {
-                    anchors.fill: parent
-                    onPaint: {
-                      var ctx = getContext("2d")
-                      ctx.reset()
-                      ctx.strokeStyle = Style.selectedStateColor(root.contentForeground, Color.accent)
-                      ctx.lineWidth = 2
-                      ctx.lineCap = "round"
-                      var r = width / 2 - 2
-                      ctx.beginPath()
-                      ctx.arc(width / 2, height / 2, r, -Math.PI / 2, Math.PI / 3, false)
-                      ctx.stroke()
-                    }
-                  }
-                }
-              }
-
-              Button {
-                readonly property string st: String(root.updateStates[modelData.sourceKey] || "")
-                visible: st === "CURRENT" || st === "UPDATE" || st === "LOCAL_CHANGES"
-                  || st === "LOCAL" || st === "ERROR"
-                // Icon + label: an "UPDATE" pill when a newer version is
-                // available (clickable to update), a plain check otherwise.
-                text: st === "UPDATE" ? "\uEAC2 UPDATE" : "\uF00C"
-                enabled: st === "UPDATE" && !root.updateDetachedRunning
-                onClicked: root.updatePlugin(modelData.sourceKey)
-                bordered: true
-                // Keep the idle border but drop it on hover, matching the
-                // other action buttons.
-                borderSpec: hot ? Border.none()
-                  : Border.controlSpec("normal", foreground, Color.accent)
-                foreground: st === "ERROR" ? Color.urgent : root.contentForeground
-                accent: Color.accent
-                fontFamily: root.contentFontFamily
-                fontSize: Style.font.caption
-                horizontalPadding: Style.space(8)
-                verticalPadding: Style.space(3)
-                Layout.alignment: Qt.AlignVCenter
-              }
-            }
-
-            HoverHandler {
-              id: hover
-            }
-
-            Rectangle {
-              anchors.left: parent.left
-              anchors.right: parent.right
-              anchors.bottom: parent.bottom
-              anchors.leftMargin: Style.space(10)
-              anchors.rightMargin: Style.space(10)
-              height: 1
-              color: Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.12)
-            }
-          }
-        }
-
-        RowLayout {
-          Layout.fillWidth: true
-          spacing: Style.space(8)
-
-          Label {
-            text: root.pendingUpdateCount > 0
-              ? root.pendingUpdateCount + " update" + (root.pendingUpdateCount > 1 ? "s" : "") + " available"
-              : (root.checkingUpdates ? "Checking…" : "No updates available")
-            color: Qt.darker(root.contentForeground, 1.5)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-          }
-
-          Label {
-            visible: root.updateSummary !== ""
-            text: root.updateSummary
-            textFormat: Text.PlainText
-            color: Style.selectedStateColor(root.contentForeground, Color.accent)
-            font.family: root.contentFontFamily
-            font.pixelSize: Style.font.bodySmall
-          }
-
-          Item {
-            Layout.fillWidth: true
-          }
-
-          Button {
-            text: root.updatingAll ? "Updating all…" : "Update all"
-            enabled: root.pendingUpdateCount > 0
-              && !root.checkingUpdates && !root.updateDetachedRunning
-            visible: root.pendingUpdateCount > 0
-            foreground: root.contentForeground
-            accent: Color.accent
-            fontFamily: root.contentFontFamily
-            fontSize: Style.font.bodySmall
-            horizontalPadding: Style.space(12)
-            verticalPadding: Style.space(6)
-            onClicked: root.updateAll()
-          }
-        }
-      }
-        }
-      }
+      onCloseRequested: root.updatesPageOpen = false
+      onTabRequested: function(direction) { root.switchPanel(direction) }
+      onOpenUrlRequested: function(url) { root.openExternal(url) }
+      onUpdatePluginRequested: function(sourceKey) { root.updatePlugin(sourceKey) }
+      onUpdateAllRequested: root.updateAll()
     }
 
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -1,12 +1,14 @@
+pragma ComponentBehavior: Bound
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
-import Quickshell.Hyprland
 import Quickshell.Io
-import Quickshell.Wayland
 import qs.Commons
 import qs.Ui
+import "panel/Presentation.js" as Presentation
+import "panel/plugin" as Plugin
 import "panel/updates" as Updates
 
 // Plugin manager popup: lists every discovered plugin (first-party omarchy +
@@ -67,50 +69,11 @@ Panel {
     var m = reg && reg.installedPlugins ? reg.installedPlugins[id] : null
     return m ? m.__isFirstParty === true : false
   }
-  function marketplaceUrlFor(id) {
-    return "https://omarchyplugins.com/plugin.html?id=" + encodeURIComponent(String(id))
-  }
-  function openMarketplacePage(id) {
-    var e = root.marketplaceEntry(id)
-    if (e) Qt.openUrlExternally(root.marketplaceUrlFor(id))
-  }
-  function shortSha(sha) {
-    var s = String(sha || "")
-    return s.length > 7 ? s.substring(0, 7) : s
-  }
-  // Listing checks section on the marketplace plugin page.
-  function listingChecksUrlFor(id) {
-    return root.marketplaceUrlFor(id) + "#verification"
-  }
-  function openListingChecks(id) {
-    if (root.marketplaceEntry(String(id))) Qt.openUrlExternally(root.listingChecksUrlFor(id))
-  }
-  // GitHub commit page for a plugin's checked-out code.
-  function commitUrlFor(sourceKey, sha) {
-    var url = String(root.pluginRepos[sourceKey] || "")
-    if (!/^https:\/\/github\.com\//.test(url)) return ""
-    var s = String(sha || "")
-    if (s === "") return ""
-    url = url.replace(/\.git\/?$/, "").replace(/\/+$/, "")
-    return url + "/commit/" + s
-  }
-  // GitHub profile of the plugin's repository owner.
-  function authorUrlFor(sourceKey) {
-    var url = String(root.pluginRepos[sourceKey] || "")
-    var m = url.replace(/\.git\/?$/, "").match(/^https:\/\/github\.com\/([^\/]+)/)
-    return m ? "https://github.com/" + m[1] : ""
-  }
   // GitHub compare URL from the listing's snapshot-checked commit to the
   // locally installed commit. Only http(s) GitHub remotes are eligible, since
   // this URL goes to the browser.
   function compareUrlFor(sourceKey, fromSha, toSha) {
-    var url = String(root.pluginRepos[sourceKey] || "")
-    if (!/^https:\/\/github\.com\//.test(url)) return ""
-    var f = String(fromSha || "")
-    var t = String(toSha || "")
-    if (f === "" || t === "" || f === t) return ""
-    url = url.replace(/\.git\/?$/, "").replace(/\/+$/, "")
-    return url + "/compare/" + f + "..." + t
+    return Presentation.compareUrl(root.pluginRepos[sourceKey], fromSha, toSha)
   }
   // "What's new" link for a plugin with an available update: prefer the
   // marketplace release page (release notes), otherwise the GitHub compare
@@ -184,24 +147,6 @@ Panel {
       return false
     }
     return kinds.indexOf(root.filterKind) !== -1
-  }
-
-  // Friendly, comma-joined labels for a plugin's kinds (e.g. "bar-widget"
-  // -> "Bar Widget"), falling back to the raw value when unknown.
-  function kindDisplay(kindsStr) {
-    if (!kindsStr) return ""
-    var parts = String(kindsStr).split(",")
-    var out = []
-    for (var i = 0; i < parts.length; i++) {
-      var k = parts[i].trim()
-      if (k === "") continue
-      var lbl = k
-      for (var j = 0; j < root.knownKinds.length; j++) {
-        if (root.knownKinds[j].value === k) { lbl = root.knownKinds[j].label; break }
-      }
-      out.push(lbl)
-    }
-    return out.join(", ").toUpperCase()
   }
 
   // Update checking state, keyed by the plugin folder name (sourceKey).
@@ -282,10 +227,10 @@ Panel {
     interval: 45000
     repeat: false
     onTriggered: {
-      console.log("checkWatchdog timeout, process running=", updateCheckProcess.running)
+      console.log("checkWatchdog timeout, process running=", root.updateCheckProcess.running)
       if (!root.checkingUpdates) return
-      if (updateCheckProcess.running)
-        updateCheckProcess.signal(9)
+      if (root.updateCheckProcess.running)
+        root.updateCheckProcess.signal(9)
       root.checkingUpdates = false
       root.updateSummary = "Check timed out — a repository may be unreachable"
     }
@@ -306,17 +251,6 @@ Panel {
       root.installResult = "Install timed out"
       root.installStatusPath = ""
     }
-  }
-
-  function iconColorFor(name) {
-    var hash = 0
-    for (var i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0
-    var palette = [
-      "#c0392b", "#2980b9", "#27ae60", "#d35400", "#8e44ad",
-      "#16a085", "#e67e22", "#2c3e50", "#c0272f", "#21618c",
-      "#1e8449", "#b9770e", "#7d3c98", "#117a65", "#ca6f1e"
-    ]
-    return palette[Math.abs(hash) % palette.length]
   }
 
   // Pull the icon glyph straight from the plugin's live bar widget. Each
@@ -1002,9 +936,9 @@ Panel {
     repeat: true
     running: root.updateDetachedRunning && !root.updateAwaitingStart
     onTriggered: {
-      if (!updateProbeProcess.running && /^[0-9]+$/.test(root.updateProbePid)) {
-        updateProbeProcess.command = ["bash", "-c", 'kill -0 "$0" 2>/dev/null', root.updateProbePid]
-        updateProbeProcess.running = true
+      if (!root.updateProbeProcess.running && /^[0-9]+$/.test(root.updateProbePid)) {
+        root.updateProbeProcess.command = ["bash", "-c", 'kill -0 "$0" 2>/dev/null', root.updateProbePid]
+        root.updateProbeProcess.running = true
       }
     }
   }
@@ -1188,8 +1122,8 @@ Panel {
         + "if [ $rc -ne 0 ]; then exit 1; fi; "
         + "' -- \"$0\" \"$1\" >/dev/null 2>&1 &",
         root._installPendingUrl, p]
-      installLaunchProcess.command = launch
-      installLaunchProcess.running = true
+      root.installLaunchProcess.command = launch
+      root.installLaunchProcess.running = true
     }
   }
 
@@ -1739,631 +1673,48 @@ Panel {
             }
           }
 
-          delegate: Item {
-            id: rowWrapper
-            required property var modelData
-            required property int index
+          delegate: Plugin.Row {
+            id: pluginRow
+
             width: pluginList.width
-            height: pluginRowDelegate.height + Style.space(9)
+            rowCount: pluginList.count
+            marketplaceEntry: pluginRow.modelData.firstParty
+              ? null
+              : (root.marketplaceMap[String(pluginRow.modelData.id)] || null)
+            localCommit: root.pluginCommits[String(pluginRow.modelData.sourceKey)] || ""
+            repoUrl: root.pluginRepos[String(pluginRow.modelData.sourceKey)] || ""
+            repoKnown: root.pluginRepos[String(pluginRow.modelData.sourceKey)] !== undefined
+            updateState: String(root.updateStates[String(pluginRow.modelData.sourceKey)] || "")
+            removeSelectMode: root.removeSelectMode
+            selectedForRemoval: root.removeSelection[pluginRow.modelData.id] === true
+            removingPlugin: root.removingPlugin
+            pluginEnabled: root.pluginEnabled(pluginRow.modelData.id)
+            updateRunning: root.updateDetachedRunning
+            updatingId: root.updatingId
+            icon: root.iconFor(pluginRow.modelData.id)
+            knownKinds: root.knownKinds
+            foreground: root.contentForeground
+            fontFamily: root.contentFontFamily
 
-            Rectangle {
-            id: pluginRowDelegate
-            readonly property bool mFirstParty: modelData.firstParty === true
-            readonly property var mEntry: mFirstParty ? null : (root.marketplaceMap[String(modelData.id)] || null)
-            readonly property bool mListed: mEntry !== null
-            readonly property bool mVerified: mListed && mEntry.verified === true
-            // Marketplace listing snapshot check commit vs installed code.
-            readonly property string mSnapshotCommit: mListed && typeof mEntry.snapshotCommit === "string" ? mEntry.snapshotCommit : ""
-            readonly property string mLocalCommit: root.pluginCommits[String(modelData.sourceKey)] || ""
-            readonly property bool mCommitKnown: mSnapshotCommit !== "" && mLocalCommit !== ""
-            readonly property bool mCommitMatches: mCommitKnown && mSnapshotCommit === mLocalCommit
-            readonly property string mCompareUrl: root.compareUrlFor(modelData.sourceKey, mSnapshotCommit, mLocalCommit)
-            readonly property string mSnapshotUrl: root.commitUrlFor(modelData.sourceKey, mSnapshotCommit)
-            readonly property string mLocalUrl: root.commitUrlFor(modelData.sourceKey, mLocalCommit)
-            readonly property string mAuthorUrl: modelData.firstParty ? "" : root.authorUrlFor(modelData.sourceKey)
-            // True when the bottom action row has a visible button, so the
-            // row can collapse entirely (and stop shifting the top row off
-            // center) for plugins that have no source/update control.
-            readonly property bool mShowSourceRow: (modelData.updatable && root.pluginRepos[String(modelData.sourceKey)] !== undefined) || (modelData.updatable && root.updateStates[String(modelData.sourceKey)] === "UPDATE")
-            width: parent.width
-            height: Math.max(Style.space(56),
-              Math.min(row.implicitHeight + Style.space(22), Style.space(120)))
-            clip: true
-            radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
-            color: hover.hovered
-              ? Style.hoverFillFor(root.contentForeground, Color.accent)
-              : "transparent"
-
-            RowLayout {
-              id: row
-              anchors.fill: parent
-              anchors.leftMargin: Style.space(10)
-              anchors.topMargin: Style.space(10)
-              anchors.rightMargin: Style.space(10)
-              anchors.bottomMargin: Style.space(10)
-              spacing: Style.space(10)
-
-              Button {
-                visible: root.removeSelectMode
-                text: root.removeSelection[modelData.id] === true ? "\uf14a" : "\uf0c8"
-                tooltipText: "Select plugin for removal"
-                enabled: !root.removingPlugin
-                Layout.alignment: Qt.AlignVCenter
-                foreground: root.contentForeground
-                accent: Color.accent
-                fontFamily: root.contentFontFamily
-                fontSize: Style.font.bodySmall
-                horizontalPadding: Style.space(6)
-                verticalPadding: Style.space(3)
-                onClicked: root.toggleRemoveSelection(modelData.id)
-              }
-
-              Rectangle {
-                id: pluginIcon
-                width: Style.space(28)
-                height: width
-                radius: 6
-                color: root.iconColorFor(modelData.name)
-
-                Text {
-                  anchors.centerIn: parent
-                  text: root.iconFor(modelData.id) || modelData.name.trim().charAt(0).toUpperCase()
-                  textFormat: Text.PlainText
-                  color: "white"
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.bodySmall
-                  font.bold: true
-                }
-              }
-
-              ColumnLayout {
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignVCenter
-                spacing: Style.space(2)
-
-                RowLayout {
-                  Layout.fillWidth: true
-                  spacing: Style.space(8)
-
-                  Label {
-                    id: pluginNameLabel
-                    text: modelData.name
-                    textFormat: Text.PlainText
-                    color: root.contentForeground
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.body
-                    font.bold: true
-                    // Size to the name's content so the badge/version hug the
-                    // name (right after it), not the far-right edge.
-                    // minimumWidth 0 lets it shrink + elide instead of pushing
-                    // the action column out when the name is very long (#4).
-                    Layout.minimumWidth: 0
-                    elide: Label.ElideRight
-                  }
-
-                  Rectangle {
-                    id: marketplaceBadge
-                    visible: pluginRowDelegate.mListed
-                    radius: height / 2
-                    implicitWidth: badgeRow.implicitWidth + Style.space(10)
-                    implicitHeight: Style.space(16)
-                    color: pluginRowDelegate.mVerified
-                      ? Util.alpha(Color.accent, 0.18)
-                      : Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.08)
-
-                    Row {
-                      id: badgeRow
-                      anchors.centerIn: parent
-                      spacing: Style.space(3)
-
-                      Text {
-                        visible: pluginRowDelegate.mVerified
-                        text: "\uf058"
-                        textFormat: Text.PlainText
-                        color: Color.accent
-                        font.family: root.contentFontFamily
-                        font.pixelSize: Style.font.caption - 1
-                        anchors.verticalCenter: parent.verticalCenter
-                      }
-
-                      Text {
-                        text: pluginRowDelegate.mVerified
-                          ? "Verified"
-                          : "Unverified"
-                        textFormat: Text.PlainText
-                        color: pluginRowDelegate.mVerified
-                          ? Color.accent
-                          : Qt.darker(root.contentForeground, 2.0)
-                        font.family: root.contentFontFamily
-                        font.pixelSize: Style.font.caption - 1
-                        anchors.verticalCenter: parent.verticalCenter
-                      }
-                    }
-                  }
-
-                  Label {
-                    visible: modelData.version !== "unknown"
-                    text: "v" + modelData.version
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-                }
-
-                Label {
-                  text: modelData.description !== "" ? modelData.description : "No description"
-                  textFormat: Text.PlainText
-                  color: Qt.darker(root.contentForeground, 1.6)
-                  font.family: root.contentFontFamily
-                  font.pixelSize: Style.font.bodySmall
-                  Layout.fillWidth: true
-                  Layout.minimumWidth: 0
-                  wrapMode: Label.Wrap
-                  maximumLineCount: 2
-                  elide: Label.ElideRight
-                }
-
-                // Creator line under the description, linking to the
-                // repository owner's GitHub profile when derivable, with
-                // the plugin kind on the same line.
-                 RowLayout {
-                   visible: modelData.author !== ""
-                   spacing: Style.space(6)
-                   Layout.fillWidth: true
-
-                    Text {
-                      text: "by " + modelData.author + (pluginRowDelegate.mAuthorUrl !== "" ? " ↗" : "")
-                      Layout.minimumWidth: 0
-                      elide: Text.ElideRight
-                    textFormat: Text.PlainText
-                    color: pluginRowDelegate.mAuthorUrl !== ""
-                      ? Color.accent
-                      : Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: authorLinkHover.hovered && pluginRowDelegate.mAuthorUrl !== ""
-
-                    ToolTip.text: pluginRowDelegate.mAuthorUrl !== "" ? pluginRowDelegate.mAuthorUrl : ("by " + modelData.author)
-                    ToolTip.visible: authorLinkHover.hovered
-                    ToolTip.delay: 400
-
-                    HoverHandler {
-                      id: authorLinkHover
-                      cursorShape: pluginRowDelegate.mAuthorUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-
-                     MouseArea {
-                       anchors.fill: parent
-                       enabled: pluginRowDelegate.mAuthorUrl !== ""
-                       cursorShape: Qt.PointingHandCursor
-                       onClicked: Qt.openUrlExternally(pluginRowDelegate.mAuthorUrl)
-                     }
-                   }
-
-                   Text {
-                     visible: root.kindDisplay(modelData.kinds) !== ""
-                     text: "·"
-                     textFormat: Text.PlainText
-                     color: Qt.darker(root.contentForeground, 2.0)
-                     font.family: root.contentFontFamily
-                     font.pixelSize: Style.font.caption
-                   }
-
-                   Label {
-                     visible: root.kindDisplay(modelData.kinds) !== ""
-                     text: root.kindDisplay(modelData.kinds)
-                     textFormat: Text.PlainText
-                     color: Qt.darker(root.contentForeground, 2.0)
-                     font.family: root.contentFontFamily
-                     font.pixelSize: Style.font.caption
-                     elide: Label.ElideRight
-                     Layout.minimumWidth: 0
-                     Layout.alignment: Qt.AlignRight
-                   }
-
-                   Item {
-                     Layout.fillWidth: true
-                     Layout.preferredHeight: 1
-                   }
-                 }
-
-                // Marketplace listing links on their own line under the
-                // description row, pipe-separated: the listing page, the
-                // snapshot-checked commit (linked), the installed commit when
-                // it has moved on, and the listing checks page. The text
-                // links flex and elide so this line never pushes the action
-                // buttons off the right edge.
-                RowLayout {
-                  visible: pluginRowDelegate.mListed
-                  spacing: Style.space(6)
-                  Layout.fillWidth: true
-
-                  // Marketplace icon: the site favicon (Lucide "cable", ISC
-                  // licensed), embedded as a transparent PNG data URI so the
-                  // panel stays self-contained, plus a trailing arrow. A plain
-                  // Item wrapper so hover/tap and the tooltip behave like the
-                  // text links above.
-                  Item {
-                    id: marketLink
-                    readonly property int _gap: 2
-                    width: marketIcon.width + marketArrow.implicitWidth + _gap
-                    height: Math.max(marketIcon.height, marketArrow.implicitHeight)
-                    Layout.alignment: Qt.AlignVCenter
-
-                    Image {
-                      id: marketIcon
-                      anchors.verticalCenter: parent.verticalCenter
-                      source: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAADb0lEQVRYhe2WTWhcVRTHf+fNNAmh1tFQsISUErMSwUicSbOpLTSLiEUTECaTEl2JKEVU6MKvjboRFAu6cCNB7CNS0SKxWbQqtJCYSYsR6spa1Cgu2spYQup85P1d3DfT92YyHcTpqv3D4557vt+599x74TZudVg9Q08Npih1PA922vylbwGUG94H2kNH6YjNrBQabfZ2UVo/gPGAY/AD5cScHVu81iqBZAOn1Pki6DVQAbgrDPE5kKLUmQBejwWfSqcprc8A96GIYMvGqnLpg+Yvn/5vCYiesC4p5dL7Q26qJouq5tL9yL4Btm7iuw9sXrnhQfOXfmqWgBdzOD20E9PUdY6ddF91qoPKpvsi8o/C4AJ7AzruppzocRVEQDfow2bBob4CFe8wcOcN9Lfh2WHgkLK7d0HwcJj6jPn56NK8qcnMAMaTwD5ND+20j8/9tplDr27a7/zpEmIcNAoaRYwjLoV/fa8bgv6amezLTXwfr1HlxECzP2rcAwBmBfPzx6Ms5TJvA9uv5xp0Iq9KFxt8eEExIu9slkC8AtI/bqRbkRYVGKI7ptMm1FXAVkDjGL3kMnMSdzi2rYF6Ha3vb14CFe99tmw8A+wAHonVwOFPyskP2plAbAns2OJfkBxBfAZcjYiuOl5yxOm0Dw2b0PyFX4EnNPXQGPJOOGaQNf/sfDsDV+G1Vrm52LwN/weU3b0LT++4M6QK71Plhk8S2Es2+90vUf22VkDTmR4SwSJogmoHAY7WBF6woOlM7D5p7xKU7TnEPQAYXyHOIM4AJ0KNHVT0bNSkzUugQTfwB37+gIX9KzAmM6sYvcgejFq0twJmXW5k3SKHh4Ew1mM6IZpXIPCKtYMo8DY5y72umG4UIqXJzOOY1tzctiJSje+vGyVgyZ+hEtIaI3q7AQQ8VnMohQ+O4CIYGNuBL2rXSTSw6UIsTNMEAOUyC8AIbhnfIqn3ANjgBcTLof3X5uf3Ayib7sOz88C2Ji7/xux+O7r0e5XRYg/YIeCaC6RXqXCZCpcRr4TB10BP17Rnl1eRfRL5hdHYeSA7Gg3eMgHzl84RsAf4sUEozoPtNX/5YtyIKyFVMH/5lPnLp4BCnayGlm1os/mzGhsYItXzKEa1zVYoXJmz+QuND5GO4ruUOjbAIq9hm3DP+uKRVvFu49bDv15cMTlnbnc+AAAAAElFTkSuQmCC"
-                      width: 14
-                      height: 14
-                      fillMode: Image.PreserveAspectFit
-                      cache: false
-                    }
-
-                    Text {
-                      id: marketArrow
-                      x: marketIcon.width + parent._gap
-                      anchors.verticalCenter: parent.verticalCenter
-                      text: "↗"
-                      textFormat: Text.PlainText
-                      color: Color.accent
-                      font.family: root.contentFontFamily
-                      font.pixelSize: Style.font.caption
-                    }
-
-                    HoverHandler {
-                      id: marketLinkHover
-                      cursorShape: Qt.PointingHandCursor
-                    }
-
-                    TapHandler {
-                      onTapped: root.openMarketplacePage(modelData.id)
-                    }
-
-                    ToolTip.text: root.marketplaceUrlFor(modelData.id)
-                    ToolTip.visible: marketLinkHover.hovered
-                    ToolTip.delay: 400
-                  }
-
-                  Text {
-                    text: "|"
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.4)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-
-                  Text {
-                    visible: pluginRowDelegate.mSnapshotCommit !== ""
-                    text: "\uDB81\uDF91 " + root.shortSha(pluginRowDelegate.mSnapshotCommit)
-                    textFormat: Text.PlainText
-                    color: pluginRowDelegate.mCommitMatches ? Color.accent : Qt.darker(root.contentForeground, 1.6)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: snapLinkHover.hovered && pluginRowDelegate.mSnapshotUrl !== ""
-
-                    ToolTip.text: pluginRowDelegate.mSnapshotUrl !== ""
-                      ? pluginRowDelegate.mSnapshotUrl
-                      : pluginRowDelegate.mSnapshotCommit
-                    ToolTip.visible: snapLinkHover.hovered
-                    ToolTip.delay: 400
-
-                    HoverHandler {
-                      id: snapLinkHover
-                      cursorShape: pluginRowDelegate.mSnapshotUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      enabled: pluginRowDelegate.mSnapshotUrl !== ""
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.openUrlExternally(pluginRowDelegate.mSnapshotUrl)
-                    }
-                  }
-
-                  Text {
-                    // Listing has no snapshot commit yet: fall back to
-                    // linking the locally installed code commit alone.
-                    visible: pluginRowDelegate.mSnapshotCommit === "" && pluginRowDelegate.mLocalCommit !== ""
-                    text: "\uDB81\uDF91 " + root.shortSha(pluginRowDelegate.mLocalCommit) + (pluginRowDelegate.mLocalUrl !== "" ? " ↗" : "")
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 1.6)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: localOnlyLinkHover.hovered && pluginRowDelegate.mLocalUrl !== ""
-
-                    HoverHandler {
-                      id: localOnlyLinkHover
-                      cursorShape: pluginRowDelegate.mLocalUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      enabled: pluginRowDelegate.mLocalUrl !== ""
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.openUrlExternally(pluginRowDelegate.mLocalUrl)
-                    }
-                  }
-
-                  Text {
-                    visible: pluginRowDelegate.mSnapshotCommit !== "" && pluginRowDelegate.mLocalCommit !== "" && !pluginRowDelegate.mCommitMatches
-                    text: "→"
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.0)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-
-                  Text {
-                    visible: pluginRowDelegate.mSnapshotCommit !== "" && pluginRowDelegate.mLocalCommit !== "" && !pluginRowDelegate.mCommitMatches
-                    text: root.shortSha(pluginRowDelegate.mLocalCommit) + (pluginRowDelegate.mLocalUrl !== "" ? " ↗" : "")
-                    textFormat: Text.PlainText
-                    color: Color.accent
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: localLinkHover.hovered && pluginRowDelegate.mLocalUrl !== ""
-
-                    ToolTip.text: pluginRowDelegate.mLocalUrl !== ""
-                      ? pluginRowDelegate.mLocalUrl
-                      : pluginRowDelegate.mLocalCommit
-                    ToolTip.visible: localLinkHover.hovered
-                    ToolTip.delay: 400
-
-                    HoverHandler {
-                      id: localLinkHover
-                      cursorShape: pluginRowDelegate.mLocalUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      enabled: pluginRowDelegate.mLocalUrl !== ""
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.openUrlExternally(pluginRowDelegate.mLocalUrl)
-                    }
-                  }
-
-                  Text {
-                    visible: pluginRowDelegate.mCompareUrl !== ""
-                    text: "|"
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.4)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-
-                  Text {
-                    visible: pluginRowDelegate.mCompareUrl !== ""
-                    text: "view changes ↗"
-                    textFormat: Text.PlainText
-                    color: Color.accent
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: compareLinkHover.hovered
-                    elide: Text.ElideRight
-                    ToolTip.text: pluginRowDelegate.mCompareUrl
-                    ToolTip.visible: compareLinkHover.hovered
-                    ToolTip.delay: 400
-
-                    HoverHandler {
-                      id: compareLinkHover
-                      cursorShape: Qt.PointingHandCursor
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: Qt.openUrlExternally(pluginRowDelegate.mCompareUrl)
-                    }
-                  }
-
-                  Text {
-                    text: "|"
-                    textFormat: Text.PlainText
-                    color: Qt.darker(root.contentForeground, 2.4)
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                  }
-
-                  Text {
-                    text: "Listing checks ↗"
-                    textFormat: Text.PlainText
-                    color: Color.accent
-                    font.family: root.contentFontFamily
-                    font.pixelSize: Style.font.caption
-                    font.underline: checksLinkHover.hovered
-                    elide: Text.ElideRight
-                    Layout.fillWidth: true
-                    Layout.minimumWidth: 0
-                    ToolTip.text: root.listingChecksUrlFor(modelData.id)
-                    ToolTip.visible: checksLinkHover.hovered
-                    ToolTip.delay: 400
-
-                    HoverHandler {
-                      id: checksLinkHover
-                      cursorShape: Qt.PointingHandCursor
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      cursorShape: Qt.PointingHandCursor
-                      onClicked: root.openListingChecks(modelData.id)
-                    }
-                  }
-                }
-              }
-
-              // Action column pinned to the right edge of every row; the
-              // text columns absorb any width pressure so these controls
-              // always stay flush right. Toggle + more-actions on top,
-              // source / update buttons stacked underneath.
-              ColumnLayout {
-                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                spacing: Style.space(4)
-
-                RowLayout {
-                  // Toggle and more-actions sit adjacent, flush right.
-                  Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                  spacing: Style.space(6)
-
-                  // Inline switch: solid accent track when ON so it reads the
-                  // same as the accent-colored author / "View on marketplace"
-                  // links (ToggleSwitch's fill is too faint at 0.18 alpha).
-                  // Gated like the PR's native toggle: bar options that are
-                  // active cannot be switched off directly.
-                  Item {
-                    id: toggle
-                    readonly property bool checked: root.pluginEnabled(rowWrapper.modelData.id)
-                    readonly property bool canToggle: rowWrapper.modelData.canDisable || !toggle.checked
-                    readonly property int _h: Math.max(22, Math.round(Style.spacing.controlHeight * 0.55))
-                    readonly property int _w: Math.round(_h * 1.9)
-                    readonly property int _k: Math.max(6, Math.round(_h * 0.72))
-                    readonly property int _inset: Math.max(1, Math.round((_h - _k) / 2))
-                    implicitWidth: _w
-                    implicitHeight: _h
-                    opacity: canToggle ? 1 : 0.4
-                    Layout.alignment: Qt.AlignVCenter
-
-                    Rectangle {
-                      width: toggle._w
-                      height: toggle._h
-                      radius: Style.cornerRadius > 0 ? height / 2 : 0
-                      color: toggle.checked
-                        ? Color.accent
-                        : Style.normalFillFor(root.contentForeground, Color.accent)
-                      Behavior on color { ColorAnimation { duration: 120 } }
-
-                      Rectangle {
-                        width: toggle._k
-                        height: toggle._k
-                        radius: Style.cornerRadius > 0 ? height / 2 : 0
-                        x: toggle.checked ? toggle._w - width - toggle._inset : toggle._inset
-                        anchors.verticalCenter: parent.verticalCenter
-                        color: toggle.checked ? Color.background : Qt.darker(root.contentForeground, 1.25)
-                        Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
-                        Behavior on color { ColorAnimation { duration: 120 } }
-                      }
-                    }
-
-                    MouseArea {
-                      anchors.fill: parent
-                      cursorShape: toggle.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
-                      onClicked: {
-                        if (!toggle.canToggle) return
-                        Qt.callLater(function() { root.setPluginEnabled(rowWrapper.modelData.id, !toggle.checked) })
-                      }
-                    }
-                  }
-
-                  Button {
-                    id: rowMenuButton
-                    iconText: "\uf142"
-                    tooltipText: "More actions"
-                    visible: !modelData.firstParty
-                    bordered: true
-                    // Keep the idle border but drop it while hovered.
-                    borderSpec: hot ? Border.none()
-                      : Border.controlSpec("normal", foreground, Color.accent)
-                    foreground: root.contentForeground
-                    accent: Color.accent
-                    fontFamily: root.contentFontFamily
-                    fontSize: Style.font.bodySmall
-                    horizontalPadding: Style.space(6)
-                    verticalPadding: Style.space(3)
-                    Layout.alignment: Qt.AlignVCenter
-                    onClicked: {
-                      var btn = rowMenuButton
-                      var pt = btn.mapToItem(rowMenuOverlay, 0, btn.height)
-                      root.openRowMenu(modelData.id, pt.x, pt.y)
-                    }
-                  }
-                }
-
-                RowLayout {
-                  // Collapse completely when no source/update button shows,
-                  // so the toggle/more-actions pair stays vertically centered.
-                  visible: pluginRowDelegate.mShowSourceRow
-                  Layout.fillWidth: true
-                  spacing: Style.space(6)
-
-                  Button {
-                    visible: modelData.updatable
-                      && root.pluginRepos[modelData.sourceKey] !== undefined
-                    tooltipText: "Open plugin repository"
-                    text: "SOURCE \udb85\udd94"
-                    bordered: true
-                    // Keep the idle border but drop it while hovered.
-                    borderSpec: hot ? Border.none()
-                      : Border.controlSpec("normal", foreground, Color.accent)
-                    foreground: root.contentForeground
-                    accent: Color.accent
-                    fontFamily: root.contentFontFamily
-                    fontSize: Style.font.caption
-                    iconSize: Style.font.caption
-                    horizontalPadding: Style.space(6)
-                    verticalPadding: Style.space(3)
-                    Layout.fillWidth: true
-                    onClicked: root.openPluginRepo(modelData.sourceKey)
-                  }
-
-                  Button {
-                    visible: modelData.updatable
-                      && root.updateStates[modelData.sourceKey] === "UPDATE"
-                    text: root.updatingId === modelData.sourceKey ? "Updating…" : "Update"
-                    enabled: !root.updateDetachedRunning
-                    bordered: true
-                    // Keep the idle border but drop it while hovered.
-                    borderSpec: hot ? Border.none()
-                      : Border.controlSpec("normal", foreground, Color.accent)
-                    foreground: root.contentForeground
-                    accent: Color.accent
-                    fontFamily: root.contentFontFamily
-                    fontSize: Style.font.caption
-                    horizontalPadding: Style.space(8)
-                    verticalPadding: Style.space(3)
-                    Layout.fillWidth: true
-                    onClicked: root.updatePlugin(modelData.sourceKey)
-                  }
-                }
-              }
+            onRemovalSelectionRequested: function(pluginId) {
+              root.toggleRemoveSelection(pluginId)
             }
-
-            // Row hover background: a HoverHandler (not a MouseArea) so the row
-            // highlight never swallows hover from the toggle/update buttons —
-            // otherwise their cursor shape and hover visuals wouldn't work.
-            HoverHandler {
-              id: hover
+            onEnabledChangeRequested: function(pluginId, enabled) {
+              root.setPluginEnabled(pluginId, enabled)
             }
-
-            // Right-click opens a context menu with enable/disable, source, remove.
-            TapHandler {
-              id: rowContextTap
-              acceptedButtons: Qt.RightButton
-              onTapped: function(event) {
-                var pt = rowContextTap.mapToItem(rowMenuOverlay, event.point.position.x, event.point.position.y)
-                root.openRowMenu(modelData.id, pt.x, pt.y)
-              }
-            }
-
-            }
-
-            // Divider floats in the gap between row cards, never over text.
-            Rectangle {
-              visible: index < pluginList.count - 1
-              anchors.top: pluginRowDelegate.bottom
-              anchors.topMargin: Style.space(4)
-              anchors.left: parent.left
-              anchors.right: parent.right
-              anchors.leftMargin: Style.space(10)
-              anchors.rightMargin: Style.space(10)
-              height: 1
-              color: Qt.rgba(root.contentForeground.r, root.contentForeground.g, root.contentForeground.b, 0.12)
+            onOpenUrlRequested: function(url) { Qt.openUrlExternally(url) }
+            onSourceRequested: function(sourceKey) { root.openPluginRepo(sourceKey) }
+            onUpdateRequested: function(sourceKey) { root.updatePlugin(sourceKey) }
+            onMenuRequested: function(pluginId, sourceItem, x, y) {
+              var point = sourceItem.mapToItem(rowMenuOverlay, x, y)
+              root.openRowMenu(pluginId, point.x, point.y)
             }
           }
         }
 
         RowLayout {
           Layout.fillWidth: true
+
           spacing: Style.space(8)
 
           Label {
@@ -2421,7 +1772,6 @@ Panel {
       pendingCount: root.pendingUpdateCount
       summary: root.updateSummary
       iconFor: root.iconFor
-      iconColorFor: root.iconColorFor
       whatsNewUrlFor: root.whatsNewUrlFor
 
       onCloseRequested: root.updatesPageOpen = false

--- a/panel/Presentation.js
+++ b/panel/Presentation.js
@@ -1,0 +1,70 @@
+.pragma library
+
+function marketplaceUrl(pluginId) {
+  return "https://omarchyplugins.com/plugin.html?id=" + encodeURIComponent(String(pluginId))
+}
+
+function listingChecksUrl(pluginId) {
+  return marketplaceUrl(pluginId) + "#verification"
+}
+
+function shortSha(sha) {
+  var value = String(sha || "")
+  return value.length > 7 ? value.substring(0, 7) : value
+}
+
+function normalizedGitHubUrl(repoUrl) {
+  var url = String(repoUrl || "")
+  if (!/^https:\/\/github\.com\//.test(url)) return ""
+  return url.replace(/\.git\/?$/, "").replace(/\/+$/, "")
+}
+
+function commitUrl(repoUrl, sha) {
+  var url = normalizedGitHubUrl(repoUrl)
+  var commit = String(sha || "")
+  return url !== "" && commit !== "" ? url + "/commit/" + commit : ""
+}
+
+function authorUrl(repoUrl) {
+  var match = normalizedGitHubUrl(repoUrl).match(/^https:\/\/github\.com\/([^\/]+)/)
+  return match ? "https://github.com/" + match[1] : ""
+}
+
+function compareUrl(repoUrl, fromSha, toSha) {
+  var url = normalizedGitHubUrl(repoUrl)
+  var from = String(fromSha || "")
+  var to = String(toSha || "")
+  if (url === "" || from === "" || to === "" || from === to) return ""
+  return url + "/compare/" + from + "..." + to
+}
+
+function kindLabel(kinds, knownKinds) {
+  if (!kinds) return ""
+  var parts = String(kinds).split(",")
+  var labels = []
+  for (var i = 0; i < parts.length; i++) {
+    var kind = parts[i].trim()
+    if (kind === "") continue
+    var label = kind
+    for (var j = 0; j < knownKinds.length; j++) {
+      if (knownKinds[j].value === kind) {
+        label = knownKinds[j].label
+        break
+      }
+    }
+    labels.push(label)
+  }
+  return labels.join(", ").toUpperCase()
+}
+
+function iconColor(name) {
+  var value = String(name || "")
+  var hash = 0
+  for (var i = 0; i < value.length; i++) hash = (hash * 31 + value.charCodeAt(i)) | 0
+  var palette = [
+    "#c0392b", "#2980b9", "#27ae60", "#d35400", "#8e44ad",
+    "#16a085", "#e67e22", "#2c3e50", "#c0272f", "#21618c",
+    "#1e8449", "#b9770e", "#7d3c98", "#117a65", "#ca6f1e"
+  ]
+  return palette[Math.abs(hash) % palette.length]
+}

--- a/panel/dialogs/Confirm.qml
+++ b/panel/dialogs/Confirm.qml
@@ -1,0 +1,115 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+Rectangle {
+  id: dialog
+
+  required property bool open
+  required property string title
+  required property string message
+  required property string confirmText
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  property bool dismissEnabled: true
+  property real maximumWidth: Style.space(360)
+  property color borderColor: Style.selectedStateColor(foreground, Color.accent)
+  property color confirmForeground: foreground
+  property color confirmAccent: Color.accent
+  property bool confirmBordered: false
+  property int titleWrapMode: Text.NoWrap
+
+  signal cancelRequested
+  signal confirmRequested
+
+  visible: open
+  color: Util.alpha(panelBackground, 0.7)
+  focus: true
+  Keys.priority: Keys.BeforeItem
+  Keys.onEscapePressed: {
+    if (dialog.dismissEnabled) dialog.cancelRequested()
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: {
+      if (dialog.dismissEnabled) dialog.cancelRequested()
+    }
+  }
+
+  Rectangle {
+    id: card
+
+    anchors.centerIn: parent
+    width: Math.min(parent.width - Style.space(32), dialog.maximumWidth)
+    height: content.implicitHeight + Style.space(36)
+    color: dialog.panelBackground
+    radius: Style.cornerRadius
+    border.color: dialog.borderColor
+    border.width: 1
+
+    ColumnLayout {
+      id: content
+
+      anchors.fill: parent
+      anchors.margins: Style.space(18)
+      spacing: Style.space(12)
+
+      Text {
+        text: dialog.title
+        textFormat: Text.PlainText
+        color: dialog.foreground
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.title
+        font.bold: true
+        Layout.fillWidth: true
+        wrapMode: dialog.titleWrapMode
+      }
+
+      Text {
+        text: dialog.message
+        textFormat: Text.PlainText
+        color: Qt.darker(dialog.foreground, 1.6)
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Item { Layout.fillWidth: true }
+
+        Button {
+          text: "Cancel"
+          foreground: dialog.foreground
+          accent: Color.accent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.cancelRequested()
+        }
+
+        Button {
+          text: dialog.confirmText
+          bordered: dialog.confirmBordered
+          foreground: dialog.confirmForeground
+          accent: dialog.confirmAccent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.confirmRequested()
+        }
+      }
+    }
+  }
+}

--- a/panel/dialogs/Install.qml
+++ b/panel/dialogs/Install.qml
@@ -1,0 +1,138 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+Rectangle {
+  id: dialog
+
+  required property bool open
+  required property bool running
+  required property bool failed
+  required property string result
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  signal closeRequested
+  signal installRequested(string rawUrl)
+
+  visible: open
+  color: Util.alpha(panelBackground, 0.7)
+  focus: true
+  onOpenChanged: {
+    if (open) Qt.callLater(function() { urlField.forceActiveFocus() })
+  }
+  Keys.priority: Keys.BeforeItem
+  Keys.onEscapePressed: {
+    if (!dialog.running) dialog.closeRequested()
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: {
+      if (!dialog.running) dialog.closeRequested()
+    }
+  }
+
+  Rectangle {
+    id: card
+
+    anchors.centerIn: parent
+    width: Math.min(parent.width - Style.space(32), Style.space(360))
+    height: content.implicitHeight + Style.space(36)
+    color: dialog.panelBackground
+    radius: Style.cornerRadius
+    border.color: Style.selectedStateColor(dialog.foreground, Color.accent)
+    border.width: 1
+
+    ColumnLayout {
+      id: content
+
+      anchors.fill: parent
+      anchors.margins: Style.space(18)
+      spacing: Style.space(12)
+
+      Text {
+        text: "Install a plugin from a git repo"
+        textFormat: Text.PlainText
+        color: dialog.foreground
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.title
+        font.bold: true
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      Text {
+        text: "Plugins run as arbitrary, unsandboxed code inside your omarchy-shell process. Only add repos you trust — review the code before you enable the plugin."
+        textFormat: Text.PlainText
+        color: Qt.darker(dialog.foreground, 1.6)
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      TextField {
+        id: urlField
+
+        placeholderText: "https://github.com/acme/omarchy-weather.git"
+        foreground: dialog.foreground
+        accent: Color.accent
+        font.family: dialog.fontFamily
+        Layout.fillWidth: true
+        onAccepted: {
+          if (urlField.text.trim() !== "" && !dialog.running)
+            dialog.installRequested(urlField.text)
+        }
+      }
+
+      Text {
+        visible: dialog.result !== ""
+        text: dialog.result
+        textFormat: Text.PlainText
+        color: dialog.running ? dialog.foreground
+          : (dialog.failed ? Color.urgent
+            : Style.selectedStateColor(dialog.foreground, Color.accent))
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.caption
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Item { Layout.fillWidth: true }
+
+        Button {
+          text: dialog.result !== "" ? "Close" : "Cancel"
+          enabled: !dialog.running
+          foreground: dialog.foreground
+          accent: Color.accent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.closeRequested()
+        }
+
+        Button {
+          text: dialog.running ? "Installing…" : "Install"
+          enabled: !dialog.running
+          foreground: dialog.foreground
+          accent: Color.accent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.installRequested(urlField.text)
+        }
+      }
+    }
+  }
+}

--- a/panel/plugin/Actions.qml
+++ b/panel/plugin/Actions.qml
@@ -1,0 +1,149 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+ColumnLayout {
+  id: actions
+
+  required property var plugin
+  required property bool pluginEnabled
+  required property bool repoKnown
+  required property string updateState
+  required property bool updateRunning
+  required property string updatingId
+  required property color foreground
+  required property string fontFamily
+
+  signal enabledChangeRequested(bool enabled)
+  signal sourceRequested(string sourceKey)
+  signal updateRequested(string sourceKey)
+  signal menuRequested(var sourceItem, real x, real y)
+
+  readonly property bool showSourceRow: (plugin.updatable && repoKnown)
+    || (plugin.updatable && updateState === "UPDATE")
+
+  Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+  spacing: Style.space(4)
+
+  RowLayout {
+    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+    spacing: Style.space(6)
+
+    // Active bar options cannot be disabled directly. Their reduced opacity
+    // mirrors the native-toggle guard while still allowing disabled plugins
+    // to be enabled from this row.
+    Item {
+      id: toggle
+
+      readonly property bool checked: actions.pluginEnabled
+      readonly property bool canToggle: actions.plugin.canDisable || !checked
+      readonly property int trackHeight: Math.max(22, Math.round(Style.spacing.controlHeight * 0.55))
+      readonly property int trackWidth: Math.round(trackHeight * 1.9)
+      readonly property int knobSize: Math.max(6, Math.round(trackHeight * 0.72))
+      readonly property int inset: Math.max(1, Math.round((trackHeight - knobSize) / 2))
+
+      implicitWidth: trackWidth
+      implicitHeight: trackHeight
+      opacity: canToggle ? 1 : 0.4
+      Layout.alignment: Qt.AlignVCenter
+
+      Rectangle {
+        width: toggle.trackWidth
+        height: toggle.trackHeight
+        radius: Style.cornerRadius > 0 ? height / 2 : 0
+        color: toggle.checked
+          ? Color.accent
+          : Style.normalFillFor(actions.foreground, Color.accent)
+        Behavior on color { ColorAnimation { duration: 120 } }
+
+        Rectangle {
+          width: toggle.knobSize
+          height: toggle.knobSize
+          radius: Style.cornerRadius > 0 ? height / 2 : 0
+          x: toggle.checked ? toggle.trackWidth - width - toggle.inset : toggle.inset
+          anchors.verticalCenter: parent.verticalCenter
+          color: toggle.checked ? Color.background : Qt.darker(actions.foreground, 1.25)
+          Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+          Behavior on color { ColorAnimation { duration: 120 } }
+        }
+      }
+
+      MouseArea {
+        anchors.fill: parent
+        cursorShape: toggle.canToggle ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: {
+          if (!toggle.canToggle) return
+          Qt.callLater(function() { actions.enabledChangeRequested(!toggle.checked) })
+        }
+      }
+    }
+
+    Button {
+      id: menuButton
+
+      iconText: "\uf142"
+      tooltipText: "More actions"
+      visible: !actions.plugin.firstParty
+      bordered: true
+      borderSpec: menuButton.hot ? Border.none()
+        : Border.controlSpec("normal", menuButton.foreground, Color.accent)
+      foreground: actions.foreground
+      accent: Color.accent
+      fontFamily: actions.fontFamily
+      fontSize: Style.font.bodySmall
+      horizontalPadding: Style.space(6)
+      verticalPadding: Style.space(3)
+      Layout.alignment: Qt.AlignVCenter
+      onClicked: actions.menuRequested(menuButton, 0, menuButton.height)
+    }
+  }
+
+  RowLayout {
+    visible: actions.showSourceRow
+    Layout.fillWidth: true
+    spacing: Style.space(6)
+
+    Button {
+      id: sourceButton
+
+      visible: actions.plugin.updatable && actions.repoKnown
+      tooltipText: "Open plugin repository"
+      text: "SOURCE \uDB85\uDD94"
+      bordered: true
+      borderSpec: sourceButton.hot ? Border.none()
+        : Border.controlSpec("normal", sourceButton.foreground, Color.accent)
+      foreground: actions.foreground
+      accent: Color.accent
+      fontFamily: actions.fontFamily
+      fontSize: Style.font.caption
+      iconSize: Style.font.caption
+      horizontalPadding: Style.space(6)
+      verticalPadding: Style.space(3)
+      Layout.fillWidth: true
+      onClicked: actions.sourceRequested(actions.plugin.sourceKey)
+    }
+
+    Button {
+      id: updateButton
+
+      visible: actions.plugin.updatable && actions.updateState === "UPDATE"
+      text: actions.updatingId === actions.plugin.sourceKey ? "Updating…" : "Update"
+      enabled: !actions.updateRunning
+      bordered: true
+      borderSpec: updateButton.hot ? Border.none()
+        : Border.controlSpec("normal", updateButton.foreground, Color.accent)
+      foreground: actions.foreground
+      accent: Color.accent
+      fontFamily: actions.fontFamily
+      fontSize: Style.font.caption
+      horizontalPadding: Style.space(8)
+      verticalPadding: Style.space(3)
+      Layout.fillWidth: true
+      onClicked: actions.updateRequested(actions.plugin.sourceKey)
+    }
+  }
+}

--- a/panel/plugin/ContextMenu.qml
+++ b/panel/plugin/ContextMenu.qml
@@ -1,0 +1,112 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+Rectangle {
+  id: menu
+
+  required property bool open
+  required property var plugin
+  required property bool pluginEnabled
+  required property bool repoKnown
+  required property point requestedPosition
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  signal closeRequested
+  signal enabledChangeRequested(string pluginId, bool enabled)
+  signal sourceRequested(string sourceKey)
+  signal removalRequested(string pluginId)
+
+  visible: open
+  color: "transparent"
+  focus: true
+  Keys.priority: Keys.BeforeItem
+  Keys.onEscapePressed: menu.closeRequested()
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: menu.closeRequested()
+  }
+
+  Rectangle {
+    id: card
+
+    x: Math.min(menu.requestedPosition.x, parent.width - width - Style.space(4))
+    y: Math.min(menu.requestedPosition.y, parent.height - height - Style.space(4))
+    width: actions.implicitWidth + Style.space(8)
+    height: actions.implicitHeight + Style.space(8)
+    color: menu.panelBackground
+    radius: Style.cornerRadius
+    border.color: Util.alpha(menu.foreground, 0.2)
+    border.width: 1
+
+    ColumnLayout {
+      id: actions
+
+      anchors.fill: parent
+      anchors.margins: Style.space(4)
+      spacing: Style.space(2)
+      implicitWidth: Style.space(180)
+
+      Button {
+        text: menu.pluginEnabled
+          ? (menu.plugin && menu.plugin.canDisable ? "Disable" : "Active bar")
+          : "Enable"
+        enabled: menu.plugin && (menu.plugin.canDisable || !menu.pluginEnabled)
+        foreground: menu.foreground
+        accent: Color.accent
+        fontFamily: menu.fontFamily
+        fontSize: Style.font.bodySmall
+        horizontalPadding: Style.space(8)
+        verticalPadding: Style.space(5)
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignLeft
+        onClicked: {
+          menu.enabledChangeRequested(menu.plugin.id, !menu.pluginEnabled)
+          menu.closeRequested()
+        }
+      }
+
+      Button {
+        visible: menu.plugin && menu.plugin.sourceKey !== "" && menu.repoKnown
+        text: "Source"
+        foreground: menu.foreground
+        accent: Color.accent
+        fontFamily: menu.fontFamily
+        fontSize: Style.font.bodySmall
+        horizontalPadding: Style.space(8)
+        verticalPadding: Style.space(5)
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignLeft
+        onClicked: {
+          menu.sourceRequested(menu.plugin.sourceKey)
+          menu.closeRequested()
+        }
+      }
+
+      Button {
+        visible: menu.plugin && !menu.plugin.firstParty
+        text: "Remove"
+        foreground: Color.urgent
+        accent: Color.urgent
+        fontFamily: menu.fontFamily
+        fontSize: Style.font.bodySmall
+        horizontalPadding: Style.space(8)
+        verticalPadding: Style.space(5)
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignLeft
+        onClicked: {
+          var pluginId = menu.plugin.id
+          menu.closeRequested()
+          menu.removalRequested(pluginId)
+        }
+      }
+    }
+  }
+}

--- a/panel/plugin/ListingLinks.qml
+++ b/panel/plugin/ListingLinks.qml
@@ -1,0 +1,238 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import "../Presentation.js" as Presentation
+
+RowLayout {
+  id: links
+
+  required property string pluginId
+  required property var entry
+  required property string localCommit
+  required property string repoUrl
+  required property color foreground
+  required property string fontFamily
+
+  signal openUrlRequested(string url)
+
+  readonly property string snapshotCommit: entry && typeof entry.snapshotCommit === "string"
+    ? entry.snapshotCommit : ""
+  readonly property bool commitKnown: snapshotCommit !== "" && localCommit !== ""
+  readonly property bool commitMatches: commitKnown && snapshotCommit === localCommit
+  readonly property string compareUrl: Presentation.compareUrl(repoUrl, snapshotCommit, localCommit)
+  readonly property string snapshotUrl: Presentation.commitUrl(repoUrl, snapshotCommit)
+  readonly property string localUrl: Presentation.commitUrl(repoUrl, localCommit)
+  readonly property string marketplaceUrl: Presentation.marketplaceUrl(pluginId)
+  readonly property string checksUrl: Presentation.listingChecksUrl(pluginId)
+
+  spacing: Style.space(6)
+  Layout.fillWidth: true
+
+  // Every link can shrink or elide so this row never displaces the plugin
+  // actions at the right edge.
+  Item {
+    id: marketplaceLink
+
+    readonly property int gap: 2
+    Layout.preferredWidth: marketplaceIcon.width + marketplaceArrow.implicitWidth + gap
+    Layout.preferredHeight: Math.max(marketplaceIcon.height, marketplaceArrow.implicitHeight)
+    Layout.alignment: Qt.AlignVCenter
+
+    // Omarchy Plugins favicon, based on Lucide's ISC-licensed cable icon.
+    Image {
+      id: marketplaceIcon
+      anchors.verticalCenter: parent.verticalCenter
+      source: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABmJLR0QA/wD/AP+gvaeTAAADb0lEQVRYhe2WTWhcVRTHf+fNNAmh1tFQsISUErMSwUicSbOpLTSLiEUTECaTEl2JKEVU6MKvjboRFAu6cCNB7CNS0SKxWbQqtJCYSYsR6spa1Cgu2spYQup85P1d3DfT92YyHcTpqv3D4557vt+599x74TZudVg9Q08Npih1PA922vylbwGUG94H2kNH6YjNrBQabfZ2UVo/gPGAY/AD5cScHVu81iqBZAOn1Pki6DVQAbgrDPE5kKLUmQBejwWfSqcprc8A96GIYMvGqnLpg+Yvn/5vCYiesC4p5dL7Q26qJouq5tL9yL4Btm7iuw9sXrnhQfOXfmqWgBdzOD20E9PUdY6ddF91qoPKpvsi8o/C4AJ7AzruppzocRVEQDfow2bBob4CFe8wcOcN9Lfh2WHgkLK7d0HwcJj6jPn56NK8qcnMAMaTwD5ND+20j8/9tplDr27a7/zpEmIcNAoaRYwjLoV/fa8bgv6amezLTXwfr1HlxECzP2rcAwBmBfPzx6Ms5TJvA9uv5xp0Iq9KFxt8eEExIu9slkC8AtI/bqRbkRYVGKI7ptMm1FXAVkDjGL3kMnMSdzi2rYF6Ha3vb14CFe99tmw8A+wAHonVwOFPyskP2plAbAns2OJfkBxBfAZcjYiuOl5yxOm0Dw2b0PyFX4EnNPXQGPJOOGaQNf/sfDsDV+G1Vrm52LwN/weU3b0LT++4M6QK71Plhk8S2Es2+90vUf22VkDTmR4SwSJogmoHAY7WBF6woOlM7D5p7xKU7TnEPQAYXyHOIM4AJ0KNHVT0bNSkzUugQTfwB37+gIX9KzAmM6sYvcgejFq0twJmXW5k3SKHh4Ew1mM6IZpXIPCKtYMo8DY5y72umG4UIqXJzOOY1tzctiJSje+vGyVgyZ+hEtIaI3q7AQQ8VnMohQ+O4CIYGNuBL2rXSTSw6UIsTNMEAOUyC8AIbhnfIqn3ANjgBcTLof3X5uf3Ayib7sOz88C2Ji7/xux+O7r0e5XRYg/YIeCaC6RXqXCZCpcRr4TB10BP17Rnl1eRfRL5hdHYeSA7Gg3eMgHzl84RsAf4sUEozoPtNX/5YtyIKyFVMH/5lPnLp4BCnayGlm1os/mzGhsYItXzKEa1zVYoXJmz+QuND5GO4ruUOjbAIq9hm3DP+uKRVvFu49bDv15cMTlnbnc+AAAAAElFTkSuQmCC"
+      width: 14
+      height: 14
+      fillMode: Image.PreserveAspectFit
+      cache: false
+    }
+
+    Text {
+      id: marketplaceArrow
+      x: marketplaceIcon.width + marketplaceLink.gap
+      anchors.verticalCenter: parent.verticalCenter
+      text: "↗"
+      textFormat: Text.PlainText
+      color: Color.accent
+      font.family: links.fontFamily
+      font.pixelSize: Style.font.caption
+    }
+
+    HoverHandler {
+      id: marketplaceHover
+      cursorShape: Qt.PointingHandCursor
+    }
+
+    TapHandler {
+      onTapped: links.openUrlRequested(links.marketplaceUrl)
+    }
+
+    ToolTip.text: links.marketplaceUrl
+    ToolTip.visible: marketplaceHover.hovered
+    ToolTip.delay: 400
+  }
+
+  Text {
+    text: "|"
+    textFormat: Text.PlainText
+    color: Qt.darker(links.foreground, 2.4)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+  }
+
+  Text {
+    visible: links.snapshotCommit !== ""
+    text: "\uDB81\uDF91 " + Presentation.shortSha(links.snapshotCommit)
+    textFormat: Text.PlainText
+    color: links.commitMatches ? Color.accent : Qt.darker(links.foreground, 1.6)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+    font.underline: snapshotHover.hovered && links.snapshotUrl !== ""
+
+    ToolTip.text: links.snapshotUrl !== "" ? links.snapshotUrl : links.snapshotCommit
+    ToolTip.visible: snapshotHover.hovered
+    ToolTip.delay: 400
+
+    HoverHandler {
+      id: snapshotHover
+      cursorShape: links.snapshotUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      enabled: links.snapshotUrl !== ""
+      cursorShape: Qt.PointingHandCursor
+      onClicked: links.openUrlRequested(links.snapshotUrl)
+    }
+  }
+
+  Text {
+    visible: links.snapshotCommit === "" && links.localCommit !== ""
+    text: "\uDB81\uDF91 " + Presentation.shortSha(links.localCommit) + (links.localUrl !== "" ? " ↗" : "")
+    textFormat: Text.PlainText
+    color: Qt.darker(links.foreground, 1.6)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+    font.underline: localOnlyHover.hovered && links.localUrl !== ""
+
+    HoverHandler {
+      id: localOnlyHover
+      cursorShape: links.localUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      enabled: links.localUrl !== ""
+      cursorShape: Qt.PointingHandCursor
+      onClicked: links.openUrlRequested(links.localUrl)
+    }
+  }
+
+  Text {
+    visible: links.snapshotCommit !== "" && links.localCommit !== "" && !links.commitMatches
+    text: "→"
+    textFormat: Text.PlainText
+    color: Qt.darker(links.foreground, 2.0)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+  }
+
+  Text {
+    visible: links.snapshotCommit !== "" && links.localCommit !== "" && !links.commitMatches
+    text: Presentation.shortSha(links.localCommit) + (links.localUrl !== "" ? " ↗" : "")
+    textFormat: Text.PlainText
+    color: Color.accent
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+    font.underline: localHover.hovered && links.localUrl !== ""
+
+    ToolTip.text: links.localUrl !== "" ? links.localUrl : links.localCommit
+    ToolTip.visible: localHover.hovered
+    ToolTip.delay: 400
+
+    HoverHandler {
+      id: localHover
+      cursorShape: links.localUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      enabled: links.localUrl !== ""
+      cursorShape: Qt.PointingHandCursor
+      onClicked: links.openUrlRequested(links.localUrl)
+    }
+  }
+
+  Text {
+    visible: links.compareUrl !== ""
+    text: "|"
+    textFormat: Text.PlainText
+    color: Qt.darker(links.foreground, 2.4)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+  }
+
+  Text {
+    visible: links.compareUrl !== ""
+    text: "view changes ↗"
+    textFormat: Text.PlainText
+    color: Color.accent
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+    font.underline: compareHover.hovered
+    elide: Text.ElideRight
+    ToolTip.text: links.compareUrl
+    ToolTip.visible: compareHover.hovered
+    ToolTip.delay: 400
+
+    HoverHandler {
+      id: compareHover
+      cursorShape: Qt.PointingHandCursor
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      cursorShape: Qt.PointingHandCursor
+      onClicked: links.openUrlRequested(links.compareUrl)
+    }
+  }
+
+  Text {
+    text: "|"
+    textFormat: Text.PlainText
+    color: Qt.darker(links.foreground, 2.4)
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+  }
+
+  Text {
+    text: "Listing checks ↗"
+    textFormat: Text.PlainText
+    color: Color.accent
+    font.family: links.fontFamily
+    font.pixelSize: Style.font.caption
+    font.underline: checksHover.hovered
+    elide: Text.ElideRight
+    Layout.fillWidth: true
+    Layout.minimumWidth: 0
+    ToolTip.text: links.checksUrl
+    ToolTip.visible: checksHover.hovered
+    ToolTip.delay: 400
+
+    HoverHandler {
+      id: checksHover
+      cursorShape: Qt.PointingHandCursor
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      cursorShape: Qt.PointingHandCursor
+      onClicked: links.openUrlRequested(links.checksUrl)
+    }
+  }
+}

--- a/panel/plugin/Row.qml
+++ b/panel/plugin/Row.qml
@@ -1,0 +1,300 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+import "../Presentation.js" as Presentation
+
+Item {
+  id: pluginRow
+
+  required property var modelData
+  required property int index
+  required property int rowCount
+  required property var marketplaceEntry
+  required property string localCommit
+  required property string repoUrl
+  required property bool repoKnown
+  required property string updateState
+  required property bool removeSelectMode
+  required property bool selectedForRemoval
+  required property bool removingPlugin
+  required property bool pluginEnabled
+  required property bool updateRunning
+  required property string updatingId
+  required property string icon
+  required property var knownKinds
+  required property color foreground
+  required property string fontFamily
+
+  signal removalSelectionRequested(string pluginId)
+  signal enabledChangeRequested(string pluginId, bool enabled)
+  signal openUrlRequested(string url)
+  signal sourceRequested(string sourceKey)
+  signal updateRequested(string sourceKey)
+  signal menuRequested(string pluginId, var sourceItem, real x, real y)
+
+  readonly property bool listed: marketplaceEntry !== null
+  readonly property bool verified: listed && marketplaceEntry.verified === true
+  readonly property string authorUrl: modelData.firstParty ? "" : Presentation.authorUrl(repoUrl)
+  readonly property string kindLabel: Presentation.kindLabel(modelData.kinds, knownKinds)
+
+  height: card.height + Style.space(9)
+
+  Rectangle {
+    id: card
+
+    width: parent.width
+    height: Math.max(Style.space(56), Math.min(content.implicitHeight + Style.space(22), Style.space(120)))
+    clip: true
+    radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
+    color: hover.hovered
+      ? Style.hoverFillFor(pluginRow.foreground, Color.accent)
+      : "transparent"
+
+    RowLayout {
+      id: content
+
+      anchors.fill: parent
+      anchors.leftMargin: Style.space(10)
+      anchors.topMargin: Style.space(10)
+      anchors.rightMargin: Style.space(10)
+      anchors.bottomMargin: Style.space(10)
+      spacing: Style.space(10)
+
+      Button {
+        visible: pluginRow.removeSelectMode
+        text: pluginRow.selectedForRemoval ? "\uf14a" : "\uf0c8"
+        tooltipText: "Select plugin for removal"
+        enabled: !pluginRow.removingPlugin
+        Layout.alignment: Qt.AlignVCenter
+        foreground: pluginRow.foreground
+        accent: Color.accent
+        fontFamily: pluginRow.fontFamily
+        fontSize: Style.font.bodySmall
+        horizontalPadding: Style.space(6)
+        verticalPadding: Style.space(3)
+        onClicked: pluginRow.removalSelectionRequested(pluginRow.modelData.id)
+      }
+
+      Rectangle {
+        Layout.preferredWidth: Style.space(28)
+        Layout.preferredHeight: Layout.preferredWidth
+        radius: 6
+        color: Presentation.iconColor(pluginRow.modelData.name)
+
+        Text {
+          anchors.centerIn: parent
+          text: pluginRow.icon || pluginRow.modelData.name.trim().charAt(0).toUpperCase()
+          textFormat: Text.PlainText
+          color: "white"
+          font.family: pluginRow.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.bold: true
+        }
+      }
+
+      ColumnLayout {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
+        spacing: Style.space(2)
+
+        RowLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(8)
+
+          Label {
+            text: pluginRow.modelData.name
+            textFormat: Text.PlainText
+            color: pluginRow.foreground
+            font.family: pluginRow.fontFamily
+            font.pixelSize: Style.font.body
+            font.bold: true
+            // Keep the badge and version adjacent to the name while still
+            // letting long names shrink and elide instead of displacing the
+            // action column (#4).
+            Layout.minimumWidth: 0
+            elide: Label.ElideRight
+          }
+
+          Rectangle {
+            visible: pluginRow.listed
+            radius: height / 2
+            implicitWidth: badgeContent.implicitWidth + Style.space(10)
+            implicitHeight: Style.space(16)
+            color: pluginRow.verified
+              ? Util.alpha(Color.accent, 0.18)
+              : Qt.rgba(pluginRow.foreground.r, pluginRow.foreground.g, pluginRow.foreground.b, 0.08)
+
+            Row {
+              id: badgeContent
+              anchors.centerIn: parent
+              spacing: Style.space(3)
+
+              Text {
+                visible: pluginRow.verified
+                text: "\uf058"
+                textFormat: Text.PlainText
+                color: Color.accent
+                font.family: pluginRow.fontFamily
+                font.pixelSize: Style.font.caption - 1
+                anchors.verticalCenter: parent.verticalCenter
+              }
+
+              Text {
+                text: pluginRow.verified ? "Verified" : "Unverified"
+                textFormat: Text.PlainText
+                color: pluginRow.verified ? Color.accent : Qt.darker(pluginRow.foreground, 2.0)
+                font.family: pluginRow.fontFamily
+                font.pixelSize: Style.font.caption - 1
+                anchors.verticalCenter: parent.verticalCenter
+              }
+            }
+          }
+
+          Label {
+            visible: pluginRow.modelData.version !== "unknown"
+            text: "v" + pluginRow.modelData.version
+            textFormat: Text.PlainText
+            color: Qt.darker(pluginRow.foreground, 2.0)
+            font.family: pluginRow.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+        }
+
+        Label {
+          text: pluginRow.modelData.description !== "" ? pluginRow.modelData.description : "No description"
+          textFormat: Text.PlainText
+          color: Qt.darker(pluginRow.foreground, 1.6)
+          font.family: pluginRow.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          Layout.fillWidth: true
+          Layout.minimumWidth: 0
+          wrapMode: Label.Wrap
+          maximumLineCount: 2
+          elide: Label.ElideRight
+        }
+
+        RowLayout {
+          visible: pluginRow.modelData.author !== ""
+          spacing: Style.space(6)
+          Layout.fillWidth: true
+
+          Text {
+            text: "by " + pluginRow.modelData.author + (pluginRow.authorUrl !== "" ? " ↗" : "")
+            Layout.minimumWidth: 0
+            elide: Text.ElideRight
+            textFormat: Text.PlainText
+            color: pluginRow.authorUrl !== "" ? Color.accent : Qt.darker(pluginRow.foreground, 2.0)
+            font.family: pluginRow.fontFamily
+            font.pixelSize: Style.font.caption
+            font.underline: authorHover.hovered && pluginRow.authorUrl !== ""
+
+            ToolTip.text: pluginRow.authorUrl !== "" ? pluginRow.authorUrl : ("by " + pluginRow.modelData.author)
+            ToolTip.visible: authorHover.hovered
+            ToolTip.delay: 400
+
+            HoverHandler {
+              id: authorHover
+              cursorShape: pluginRow.authorUrl !== "" ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
+
+            MouseArea {
+              anchors.fill: parent
+              enabled: pluginRow.authorUrl !== ""
+              cursorShape: Qt.PointingHandCursor
+              onClicked: pluginRow.openUrlRequested(pluginRow.authorUrl)
+            }
+          }
+
+          Text {
+            visible: pluginRow.kindLabel !== ""
+            text: "·"
+            textFormat: Text.PlainText
+            color: Qt.darker(pluginRow.foreground, 2.0)
+            font.family: pluginRow.fontFamily
+            font.pixelSize: Style.font.caption
+          }
+
+          Label {
+            visible: pluginRow.kindLabel !== ""
+            text: pluginRow.kindLabel
+            textFormat: Text.PlainText
+            color: Qt.darker(pluginRow.foreground, 2.0)
+            font.family: pluginRow.fontFamily
+            font.pixelSize: Style.font.caption
+            elide: Label.ElideRight
+            Layout.minimumWidth: 0
+            Layout.alignment: Qt.AlignRight
+          }
+
+          Item {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+          }
+        }
+
+        ListingLinks {
+          visible: pluginRow.listed
+          pluginId: pluginRow.modelData.id
+          entry: pluginRow.marketplaceEntry
+          localCommit: pluginRow.localCommit
+          repoUrl: pluginRow.repoUrl
+          foreground: pluginRow.foreground
+          fontFamily: pluginRow.fontFamily
+          onOpenUrlRequested: function(url) { pluginRow.openUrlRequested(url) }
+        }
+      }
+
+      Actions {
+        plugin: pluginRow.modelData
+        pluginEnabled: pluginRow.pluginEnabled
+        repoKnown: pluginRow.repoKnown
+        updateState: pluginRow.updateState
+        updateRunning: pluginRow.updateRunning
+        updatingId: pluginRow.updatingId
+        foreground: pluginRow.foreground
+        fontFamily: pluginRow.fontFamily
+        onEnabledChangeRequested: function(enabled) {
+          pluginRow.enabledChangeRequested(pluginRow.modelData.id, enabled)
+        }
+        onSourceRequested: function(sourceKey) { pluginRow.sourceRequested(sourceKey) }
+        onUpdateRequested: function(sourceKey) { pluginRow.updateRequested(sourceKey) }
+        onMenuRequested: function(sourceItem, x, y) {
+          pluginRow.menuRequested(pluginRow.modelData.id, sourceItem, x, y)
+        }
+      }
+    }
+
+    HoverHandler {
+      id: hover
+    }
+
+    TapHandler {
+      id: contextTap
+      acceptedButtons: Qt.RightButton
+      onTapped: function(eventPoint) {
+        pluginRow.menuRequested(
+          pluginRow.modelData.id,
+          card,
+          eventPoint.position.x,
+          eventPoint.position.y
+        )
+      }
+    }
+  }
+
+  Rectangle {
+    visible: pluginRow.index < pluginRow.rowCount - 1
+    anchors.top: card.bottom
+    anchors.topMargin: Style.space(4)
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.leftMargin: Style.space(10)
+    anchors.rightMargin: Style.space(10)
+    height: 1
+    color: Qt.rgba(pluginRow.foreground.r, pluginRow.foreground.g, pluginRow.foreground.b, 0.12)
+  }
+}

--- a/panel/updates/Page.qml
+++ b/panel/updates/Page.qml
@@ -5,6 +5,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import qs.Commons
 import qs.Ui
+import "../Presentation.js" as Presentation
 
 Rectangle {
   id: page
@@ -24,7 +25,6 @@ Rectangle {
   required property string summary
 
   required property var iconFor
-  required property var iconColorFor
   required property var whatsNewUrlFor
 
   signal closeRequested
@@ -176,7 +176,7 @@ Rectangle {
                   Layout.preferredWidth: Style.space(28)
                   Layout.preferredHeight: Layout.preferredWidth
                   radius: 6
-                  color: page.iconColorFor(updateRow.modelData.name)
+                  color: Presentation.iconColor(updateRow.modelData.name)
 
                   Text {
                     anchors.centerIn: parent

--- a/panel/updates/Page.qml
+++ b/panel/updates/Page.qml
@@ -1,0 +1,371 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+Rectangle {
+  id: page
+
+  required property bool open
+  required property real topInset
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  required property var rows
+  required property var updateStates
+  required property bool checking
+  required property bool updateRunning
+  required property bool updatingAll
+  required property int pendingCount
+  required property string summary
+
+  required property var iconFor
+  required property var iconColorFor
+  required property var whatsNewUrlFor
+
+  signal closeRequested
+  signal tabRequested(int direction)
+  signal openUrlRequested(string url)
+  signal updatePluginRequested(string sourceKey)
+  signal updateAllRequested
+
+  visible: open
+  color: panelBackground
+
+  // Preserve scroll and delegate state after the page has been opened once.
+  property bool _stayLoaded: false
+  onOpenChanged: {
+    if (open) _stayLoaded = true
+  }
+
+  function statusText(key) {
+    var state = updateStates[key]
+    if (!state) return "Pending"
+    if (state === "CHECK") return "Checking…"
+    if (state === "CURRENT") return "Up to date"
+    if (state === "UPDATE") return "Update available"
+    if (state === "LOCAL_CHANGES") return "Local changes"
+    if (state === "LOCAL") return "Local plugin"
+    if (state === "ERROR") return "Error"
+    return state
+  }
+
+  function statusColor(key) {
+    var state = updateStates[key]
+    if (state === "UPDATE") return Style.selectedStateColor(foreground, Color.accent)
+    if (state === "ERROR") return Color.urgent
+    if (state === "CURRENT") return Qt.darker(foreground, 1.6)
+    if (state === "LOCAL_CHANGES" || state === "LOCAL") return Qt.darker(foreground, 1.5)
+    return Qt.darker(foreground, 1.4)
+  }
+
+  Loader {
+    anchors.fill: parent
+    active: page.open || page._stayLoaded
+
+    sourceComponent: Component {
+      Item {
+        PanelKeyCatcher {
+          anchors.fill: parent
+          onCloseRequested: page.closeRequested()
+          onTabRequested: function(direction) { page.tabRequested(direction) }
+        }
+
+        ColumnLayout {
+          anchors.fill: parent
+          anchors.margins: Style.space(16)
+          anchors.topMargin: page.topInset
+          spacing: Style.space(10)
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: Style.space(8)
+
+            Label {
+              text: "Check for updates"
+              color: page.foreground
+              font.family: page.fontFamily
+              font.pixelSize: Style.font.body
+              font.bold: true
+              Layout.fillWidth: true
+            }
+
+            Button {
+              text: "Back"
+              foreground: page.foreground
+              accent: Color.accent
+              fontFamily: page.fontFamily
+              fontSize: Style.font.bodySmall
+              horizontalPadding: Style.space(10)
+              verticalPadding: Style.space(5)
+              onClicked: page.closeRequested()
+            }
+          }
+
+          Rectangle {
+            id: checkProgress
+            visible: page.checking
+            Layout.fillWidth: true
+            Layout.preferredHeight: 3
+            radius: 1.5
+            color: Qt.rgba(page.foreground.r, page.foreground.g, page.foreground.b, 0.15)
+            clip: true
+
+            Rectangle {
+              id: checkProgressChunk
+              width: checkProgress.width * 0.4
+              height: checkProgress.height
+              radius: checkProgress.radius
+              color: Style.selectedStateColor(page.foreground, Color.accent)
+
+              NumberAnimation on x {
+                running: page.checking
+                loops: Animation.Infinite
+                from: -checkProgressChunk.width
+                to: checkProgress.width
+                duration: 1100
+                easing.type: Easing.InOutQuad
+              }
+            }
+          }
+
+          ListView {
+            id: updateList
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            spacing: Style.space(4)
+            model: page.rows
+            ScrollBar.vertical: ScrollBar {
+              policy: ScrollBar.AsNeeded
+              implicitWidth: Style.space(6)
+              contentItem: Rectangle {
+                implicitWidth: Style.space(6)
+                implicitHeight: Style.space(6)
+                radius: width / 2
+                color: Util.alpha(page.foreground, 0.45)
+              }
+            }
+
+            delegate: Rectangle {
+              id: updateRow
+
+              required property var modelData
+              width: updateList.width
+              height: Math.max(Style.space(52), row.implicitHeight + Style.space(16))
+              radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
+              color: hover.hovered
+                ? Style.hoverFillFor(page.foreground, Color.accent)
+                : "transparent"
+
+              RowLayout {
+                id: row
+                anchors.fill: parent
+                anchors.leftMargin: Style.space(10)
+                anchors.topMargin: Style.space(8)
+                anchors.rightMargin: Style.space(10)
+                anchors.bottomMargin: Style.space(12)
+                spacing: Style.space(10)
+
+                Rectangle {
+                  id: updateIcon
+                  Layout.preferredWidth: Style.space(28)
+                  Layout.preferredHeight: Layout.preferredWidth
+                  radius: 6
+                  color: page.iconColorFor(updateRow.modelData.name)
+
+                  Text {
+                    anchors.centerIn: parent
+                    text: page.iconFor(updateRow.modelData.id) || updateRow.modelData.name.trim().charAt(0).toUpperCase()
+                    textFormat: Text.PlainText
+                    color: "white"
+                    font.family: page.fontFamily
+                    font.pixelSize: Style.font.bodySmall
+                    font.bold: true
+                  }
+                }
+
+                ColumnLayout {
+                  Layout.fillWidth: true
+                  Layout.alignment: Qt.AlignVCenter
+                  spacing: Style.space(2)
+
+                  Label {
+                    text: updateRow.modelData.name
+                    textFormat: Text.PlainText
+                    color: page.foreground
+                    font.family: page.fontFamily
+                    font.pixelSize: Style.font.body
+                    font.bold: true
+                    Layout.fillWidth: true
+                    elide: Label.ElideRight
+                  }
+
+                  Label {
+                    text: page.statusText(updateRow.modelData.sourceKey)
+                    textFormat: Text.PlainText
+                    color: page.statusColor(updateRow.modelData.sourceKey)
+                    font.family: page.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+
+                  Text {
+                    id: whatsNewLink
+                    readonly property string url: page.whatsNewUrlFor(updateRow.modelData.sourceKey, updateRow.modelData.id)
+                    visible: page.updateStates[String(updateRow.modelData.sourceKey)] === "UPDATE" && url !== ""
+                    text: "What's new ↗"
+                    textFormat: Text.PlainText
+                    color: Color.accent
+                    font.family: page.fontFamily
+                    font.pixelSize: Style.font.caption
+                    font.underline: whatsNewLinkHover.hovered
+                    ToolTip.text: url
+                    ToolTip.visible: whatsNewLinkHover.hovered
+                    ToolTip.delay: 400
+
+                    HoverHandler {
+                      id: whatsNewLinkHover
+                      cursorShape: Qt.PointingHandCursor
+                    }
+
+                    MouseArea {
+                      anchors.fill: parent
+                      cursorShape: Qt.PointingHandCursor
+                      onClicked: page.openUrlRequested(whatsNewLink.url)
+                    }
+                  }
+                }
+
+                Item {
+                  id: checkRing
+                  visible: page.updateStates[updateRow.modelData.sourceKey] === "CHECK"
+                    || page.updateStates[updateRow.modelData.sourceKey] === undefined
+                  Layout.alignment: Qt.AlignVCenter
+                  Layout.preferredWidth: Style.space(18)
+                  Layout.preferredHeight: Style.space(18)
+
+                  Rectangle {
+                    anchors.fill: parent
+                    radius: width / 2
+                    color: "transparent"
+                    border.width: 2
+                    border.color: Qt.rgba(page.foreground.r, page.foreground.g, page.foreground.b, 0.18)
+                  }
+
+                  Item {
+                    id: checkRingArc
+                    anchors.fill: parent
+                    visible: page.updateStates[updateRow.modelData.sourceKey] === "CHECK"
+                      || page.updateStates[updateRow.modelData.sourceKey] === undefined
+
+                    RotationAnimation on rotation {
+                      running: checkRingArc.visible
+                      loops: Animation.Infinite
+                      from: 0
+                      to: 360
+                      duration: 900
+                    }
+
+                    Canvas {
+                      anchors.fill: parent
+                      onPaint: {
+                        var context = getContext("2d")
+                        context.reset()
+                        context.strokeStyle = Style.selectedStateColor(page.foreground, Color.accent)
+                        context.lineWidth = 2
+                        context.lineCap = "round"
+                        var radius = width / 2 - 2
+                        context.beginPath()
+                        context.arc(width / 2, height / 2, radius, -Math.PI / 2, Math.PI / 3, false)
+                        context.stroke()
+                      }
+                    }
+                  }
+                }
+
+                Button {
+                  id: statusButton
+
+                  readonly property string updateState: String(page.updateStates[updateRow.modelData.sourceKey] || "")
+                  visible: updateState === "CURRENT" || updateState === "UPDATE" || updateState === "LOCAL_CHANGES"
+                    || updateState === "LOCAL" || updateState === "ERROR"
+                  text: updateState === "UPDATE" ? "\uEAC2 UPDATE" : "\uF00C"
+                  enabled: updateState === "UPDATE" && !page.updateRunning
+                  onClicked: page.updatePluginRequested(updateRow.modelData.sourceKey)
+                  bordered: true
+                  borderSpec: statusButton.hot ? Border.none()
+                    : Border.controlSpec("normal", statusButton.foreground, Color.accent)
+                  foreground: updateState === "ERROR" ? Color.urgent : page.foreground
+                  accent: Color.accent
+                  fontFamily: page.fontFamily
+                  fontSize: Style.font.caption
+                  horizontalPadding: Style.space(8)
+                  verticalPadding: Style.space(3)
+                  Layout.alignment: Qt.AlignVCenter
+                }
+              }
+
+              HoverHandler {
+                id: hover
+              }
+
+              Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                anchors.leftMargin: Style.space(10)
+                anchors.rightMargin: Style.space(10)
+                height: 1
+                color: Qt.rgba(page.foreground.r, page.foreground.g, page.foreground.b, 0.12)
+              }
+            }
+          }
+
+          RowLayout {
+            Layout.fillWidth: true
+            spacing: Style.space(8)
+
+            Label {
+              text: page.pendingCount > 0
+                ? page.pendingCount + " update" + (page.pendingCount > 1 ? "s" : "") + " available"
+                : (page.checking ? "Checking…" : "No updates available")
+              color: Qt.darker(page.foreground, 1.5)
+              font.family: page.fontFamily
+              font.pixelSize: Style.font.bodySmall
+            }
+
+            Label {
+              visible: page.summary !== ""
+              text: page.summary
+              textFormat: Text.PlainText
+              color: Style.selectedStateColor(page.foreground, Color.accent)
+              font.family: page.fontFamily
+              font.pixelSize: Style.font.bodySmall
+            }
+
+            Item {
+              Layout.fillWidth: true
+            }
+
+            Button {
+              text: page.updatingAll ? "Updating all…" : "Update all"
+              enabled: page.pendingCount > 0 && !page.checking && !page.updateRunning
+              visible: page.pendingCount > 0
+              foreground: page.foreground
+              accent: Color.accent
+              fontFamily: page.fontFamily
+              fontSize: Style.font.bodySmall
+              horizontalPadding: Style.space(12)
+              verticalPadding: Style.space(6)
+              onClicked: page.updateAllRequested()
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hey! Following up on #5 and the review of #1.

Even small presentation edits required reasoning across a roughly 3.2k-line `Panel.qml`: plugin metadata, marketplace links, actions, update progress, overlays, and dialogs sat beside process and detached-job orchestration.

This refactor is intentionally boring: `Panel.qml` still owns state and orchestration, while presentation is split into focused views with explicit properties and semantic signals. It is now roughly 1.9k lines, without introducing a controller or service layer.

## Structure

```text
panel/
├── Presentation.js
├── dialogs/
│   ├── Confirm.qml
│   └── Install.qml
├── plugin/
│   ├── Actions.qml
│   ├── ContextMenu.qml
│   ├── ListingLinks.qml
│   └── Row.qml
└── updates/
    └── Page.qml
```

## What changed

- Extracted the updates list/progress view from the update runner's parent while preserving lazy loading and page state.
- Split the plugin delegate's metadata, marketplace commit links, toggles, and update actions into focused components, and extracted its context-menu overlay.
- Reused a confirmation component for remove, restart, and install decisions.
- Moved the persistent install URL field and focus behavior into `Install.qml`. Hidden child-ID access was replaced with explicit signals, including returning install input to the panel for validation.
- Added side-effect-free helpers for URLs, SHA labels, plugin-kind labels, and deterministic icon colors.
- Kept update, install, remove, restart, registry, and native-toggle orchestration in `Panel.qml`.
- Enabled bound component behavior and removed actionable unqualified-access, layout-positioning, and unused-import diagnostics, addressing nested reliance on surrounding QML scope and layout-managed items assigning their own dimensions.
- Preserved the rationale around long-name containment, native-toggle gating, flexible marketplace links, and the embedded icon's provenance.

## Behavior-neutral cleanup

`TapHandler.tapped` supplies a `QEventPoint`, so the extracted right-click handler now reads `eventPoint.position` rather than `event.point.position`. This preserves row-relative menu placement and was manually verified near the panel edges.

No user-facing behavior changes are intended in this PR.

## Validation

- `qmllint` exits successfully across all QML files. The extracted code has no actionable unqualified-access, layout-positioning, property-override, or unused-import diagnostics locally; remaining warnings come from external Quickshell/Omarchy type metadata unavailable to the standalone linter.
- `omarchy plugin validate .` passes.
- All existing test suites pass: plugin-state, update-helper, and detached Quickshell launch.
- Each commit was manually tested sequentially against the live shell: updates page; plugin rows, links, filters, toggles, and selection; context-menu placement, dismissal, and actions; remove, restart, install, and install-confirm dialogs.
- A final live smoke test was repeated after the warning-cleanup amendment.

Live checks covered Back/Escape handling, focus behavior, scroll retention, native-plugin toggling, restored bar placement, edge-positioned menus, invalid install input, and confirmation cancellation.

Closes #5
