### PR TITLE
feat(bar): choose which bar section plugins go to (default + per-plugin move)

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -37,6 +37,40 @@ Panel {
   property var pluginRows: []
   property var rememberedBarStates: ({})
 
+  // Per-widget overrides read from omaplug's own shell.json layout entry.
+  // BarWidget.qml forwards this once the bar host injects it. We use it to
+  // remember which bar section freshly enabled bar-widget plugins land in.
+  property var settings: ({})
+  readonly property var barSections: ["left", "center", "right"]
+  // Where `setPluginEnabled` drops a bar-widget that has no remembered spot.
+  // Bound to the persisted setting; the section dropdown reassigns it.
+  property string targetSection: (root.settings
+      && root.barSections.indexOf(String(root.settings.defaultSection)) !== -1)
+    ? String(root.settings.defaultSection) : "center"
+
+  // Persist the chosen section into omaplug's own bar entry in shell.json,
+  // reusing the same registry path restoreBarSettings() uses for plugins.
+  function persistTargetSection(value) {
+    var reg = root.registry
+    if (!reg || typeof reg.setBarWidget !== "function") return
+    var error = reg.setBarWidget("omaplug", "defaultSection", value, {})
+    if (error) console.warn("omaplug: could not persist defaultSection: " + error)
+  }
+
+  // Move an already-placed bar-widget plugin to another bar section. Lands it
+  // at that section's usual anchor spot, matching `omarchy bar move`.
+  function movePlugin(id, section) {
+    var reg = root.registry
+    if (!reg || typeof reg.moveBarWidget !== "function") return
+    if (root.barSections.indexOf(section) === -1) return
+    var error = reg.moveBarWidget(id, { section: section })
+    if (error) {
+      console.warn("omaplug: could not move " + id + " to " + section + ": " + error)
+      return
+    }
+    root.refreshPlugins()
+  }
+
   // The shell injects the PluginRegistry into the bar's `shell` (the built-in
   // Bar.qml exposes no `pluginRegistry` property itself), so resolve it there
   // with a fallback for custom bars that do carry the registry directly.
@@ -1319,7 +1353,9 @@ Panel {
     var current = value ? null : root.barStateFor(id)
     var changed = remembered
       ? reg.setEnabled(id, true, remembered)
-      : reg.setEnabled(id, value)
+      : (value
+        ? reg.setEnabled(id, true, { section: root.targetSection })
+        : reg.setEnabled(id, false))
     if (!changed) return
     if (!value && current) root.rememberBarState(id, current)
     else if (value && remembered) {
@@ -1543,7 +1579,7 @@ Panel {
       PanelKeyCatcher {
         id: keyCatcher
         anchors.fill: parent
-        blocked: searchField.activeFocus || filterDropdown.popupOpen
+        blocked: searchField.activeFocus || filterDropdown.popupOpen || sectionDropdown.popupOpen
         onCloseRequested: root.close()
         onTabRequested: function(direction) { root.switchPanel(direction) }
       }
@@ -1609,6 +1645,41 @@ Panel {
               if (!root.removeSelectMode) root.removeSelection = {}
             }
           }
+        }
+
+        RowLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(6)
+
+          Label {
+            text: "New plugins go to"
+            color: root.contentForeground
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+
+          Dropdown {
+            id: sectionDropdown
+            Layout.preferredWidth: Style.space(110)
+            showLabel: false
+            value: root.targetSection
+            options: [
+              { value: "left", label: "Left" },
+              { value: "center", label: "Center" },
+              { value: "right", label: "Right" }
+            ]
+            foreground: root.contentForeground
+            background: root.panelBackground
+            popupBorder: Util.alpha(root.contentForeground, 0.2)
+            accent: Color.accent
+            fontFamily: root.contentFontFamily
+            onChanged: function(v) {
+              root.targetSection = v
+              root.persistTargetSection(v)
+            }
+          }
+
+          Item { Layout.fillWidth: true }
         }
 
         RowLayout {
@@ -1802,6 +1873,9 @@ Panel {
       foreground: root.contentForeground
       fontFamily: root.contentFontFamily
       panelBackground: root.panelBackground
+      pluginSection: rowMenuOverlay.plugin
+        ? ((root.barStateFor(rowMenuOverlay.plugin.id) || {}).section || "")
+        : ""
 
       onCloseRequested: root.closeRowMenu()
       onEnabledChangeRequested: function(pluginId, enabled) {
@@ -1809,6 +1883,10 @@ Panel {
       }
       onSourceRequested: function(sourceKey) { root.openPluginRepo(sourceKey) }
       onRemovalRequested: function(pluginId) { root.removePlugin(pluginId) }
+      onMoveRequested: function(pluginId, section) {
+        root.movePlugin(pluginId, section)
+        root.closeRowMenu()
+      }
     }
 
     Dialogs.Confirm {

--- a/panel/plugin/ContextMenu.qml
+++ b/panel/plugin/ContextMenu.qml
@@ -17,11 +17,19 @@ Rectangle {
   required property color foreground
   required property string fontFamily
   required property color panelBackground
+  // Bar section the plugin currently sits in ("left"/"center"/"right"), or
+  // "" when it is not a placed bar widget. Drives the Move-to selector.
+  required property string pluginSection
 
   signal closeRequested
   signal enabledChangeRequested(string pluginId, bool enabled)
   signal sourceRequested(string sourceKey)
   signal removalRequested(string pluginId)
+  signal moveRequested(string pluginId, string section)
+
+  readonly property bool canMove: menu.plugin
+    && menu.pluginEnabled
+    && String(menu.plugin.kinds).indexOf("bar-widget") !== -1
 
   visible: open
   color: "transparent"
@@ -70,6 +78,53 @@ Rectangle {
         onClicked: {
           menu.enabledChangeRequested(menu.plugin.id, !menu.pluginEnabled)
           menu.closeRequested()
+        }
+      }
+
+      // Move a placed bar widget between the left / center / right sections.
+      // The button for the current section is disabled so it reads as state.
+      ColumnLayout {
+        visible: menu.canMove
+        Layout.fillWidth: true
+        spacing: Style.space(2)
+
+        Label {
+          text: "Move to section"
+          color: Util.alpha(menu.foreground, 0.6)
+          font.family: menu.fontFamily
+          font.pixelSize: Style.font.caption
+          Layout.leftMargin: Style.space(8)
+          Layout.topMargin: Style.space(4)
+        }
+
+        RowLayout {
+          Layout.fillWidth: true
+          spacing: Style.space(2)
+
+          Repeater {
+            model: [
+              { value: "left", label: "Left" },
+              { value: "center", label: "Center" },
+              { value: "right", label: "Right" }
+            ]
+
+            Button {
+              required property var modelData
+              text: modelData.label
+              enabled: menu.pluginSection !== modelData.value
+              foreground: menu.foreground
+              accent: Color.accent
+              fontFamily: menu.fontFamily
+              fontSize: Style.font.bodySmall
+              horizontalPadding: Style.space(6)
+              verticalPadding: Style.space(5)
+              Layout.fillWidth: true
+              onClicked: {
+                menu.moveRequested(menu.plugin.id, modelData.value)
+                menu.closeRequested()
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## What

Adds UI control over **which bar section** (left / center / right) plugins land in. Today a bar-widget enabled from the manager goes to whatever its manifest declares, falling back to `center`, with no way to change it from omaplug.

### 1. "New plugins go to" selector (panel header)
Sets the default section for **freshly enabled** bar-widget plugins. Passed straight to `registry.setEnabled(id, true, { section })`. The choice is persisted into omaplug's own `shell.json` entry via `registry.setBarWidget(...)`, so it survives a shell restart (read back through the injected `settings`).

Re-enabling a plugin that has a *remembered* position still restores that exact spot — the new default only applies when there's nothing to restore.

### 2. "Move to section" row (per-plugin context menu)
New block in the row action menu (alongside Enable/Disable/Source/Remove). Shows only for **enabled bar-widget** plugins. The button for the section the plugin is currently in is disabled, so it doubles as a "you are here" indicator. Calls `registry.moveBarWidget(id, { section })`, which drops it at that section's normal anchor spot — same behaviour as `omarchy bar move <id> --section <…>`.

## Implementation notes
- No new dependencies, no new file IO. Both features route through the existing `PluginRegistry` API that omaplug already uses for enable/disable and `restoreBarSettings`.
- `Panel.qml` gains a `settings` property so `BarWidget.qml`'s existing `settings` forward actually reaches the panel.
- `ContextMenu.qml` gains a `pluginSection` prop + `moveRequested` signal.

## Testing
Manual, on Omarchy 4.x / Quickshell:
- Set selector to Left/Right, enable a disabled bar-widget plugin → lands in the chosen section.
- Disable + re-enable → returns to its previous exact position (unchanged path).
- Restart shell → selector remembers the choice.
- Context menu → "Move to section" relocates a placed plugin; current-section button greyed out.
- Non-bar-widget plugins show no move UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)