### PR TITLE
Add drag-and-drop bar reorder

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1565,24 +1565,6 @@ Panel {
               }
 
               Button {
-                id: reorderBarButton
-                text: "\uf0dc  Reorder bar"
-                tooltipText: "Drag and drop to reorder the widgets on the bar"
-                bordered: true
-                foreground: root.contentForeground
-                accent: Color.accent
-                fontFamily: root.contentFontFamily
-                fontSize: Style.font.caption
-                horizontalPadding: Style.space(8)
-                verticalPadding: Style.space(3)
-                Layout.alignment: Qt.AlignVCenter
-                onClicked: {
-                  root.reorderLayoutSnapshot = root.currentBarLayout()
-                  root.reorderDialogOpen = true
-                }
-              }
-
-              Button {
                 id: restartShellButton
                 text: "\uf021  Restart shell"
                 tooltipText: "Clear the QML cache and restart the shell so every plugin reloads from source"
@@ -1662,6 +1644,21 @@ Panel {
             onClicked: {
               root.updatesPageOpen = true
               if (!root.checkingUpdates) root.checkUpdates()
+            }
+          }
+
+          Button {
+            iconText: "\uf0dc"
+            tooltipText: "Reorder bar"
+            foreground: root.contentForeground
+            accent: Color.accent
+            fontFamily: root.contentFontFamily
+            fontSize: Style.font.bodySmall
+            horizontalPadding: Style.space(10)
+            verticalPadding: Style.space(5)
+            onClicked: {
+              root.reorderLayoutSnapshot = root.currentBarLayout()
+              root.reorderDialogOpen = true
             }
           }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -209,6 +209,12 @@ Panel {
   // relaunches the shell so plugins reload from source (fixes stale compiled
   // plugin QML that a live rescan would keep serving).
   property bool restartConfirmOpen: false
+  // Drag-and-drop bar reorder popup. The snapshot is taken explicitly when
+  // the popup opens (not a live binding) so the dialog gets a stable layout
+  // to preview against instead of one that could shift under an in-progress
+  // drag if something else touched the bar concurrently.
+  property bool reorderDialogOpen: false
+  property var reorderLayoutSnapshot: ({ left: [], center: [], right: [] })
   // Right-click context menu on a main-page row.
   property bool rowMenuOpen: false
   property string rowMenuId: ""
@@ -1262,6 +1268,57 @@ Panel {
     root.scanPluginRepos()
   }
 
+  // Snapshot of every widget currently on the bar, grouped by section, for
+  // the reorder popup. Reads the same shellConfigProvider().bar.layout
+  // barStateFor() reads below, plus the name/icon lookups already used
+  // elsewhere in this file (installedPlugins, iconFor).
+  function currentBarLayout() {
+    var reg = root.registry
+    var config = reg && typeof reg.shellConfigProvider === "function"
+      ? reg.shellConfigProvider()
+      : null
+    var layout = config && config.bar ? config.bar.layout : null
+    var result = { left: [], center: [], right: [] }
+    if (!layout) return result
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var entries = Array.isArray(layout[sections[s]]) ? layout[sections[s]] : []
+      for (var i = 0; i < entries.length; i++) {
+        var id = reg && typeof reg.barEntryId === "function"
+          ? reg.barEntryId(entries[i])
+          : (entries[i] && typeof entries[i] === "object" ? entries[i].id : entries[i])
+        id = String(id || "")
+        if (id === "") continue
+        var manifest = reg && reg.installedPlugins ? reg.installedPlugins[id] : null
+        result[sections[s]].push({
+          widgetId: id,
+          label: (manifest && manifest.name) || id,
+          icon: root.iconFor(id)
+        })
+      }
+    }
+    return result
+  }
+
+  // Applies a { left, center, right } id order (from the reorder popup) via
+  // the registry's moveBarWidget — the same verb `omarchy bar move` and this
+  // plugin's own enable/disable actions already use, so it stays live and
+  // persisted the same way. Placing ids in ascending target-index order
+  // converges to the exact desired permutation in one pass regardless of
+  // where an id currently sits, including across sections.
+  function applyBarOrder(order) {
+    var reg = root.registry
+    if (!reg || typeof reg.moveBarWidget !== "function" || !order) return
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var ids = Array.isArray(order[sections[s]]) ? order[sections[s]] : []
+      for (var i = 0; i < ids.length; i++) {
+        var error = reg.moveBarWidget(String(ids[i]), { section: sections[s], index: i })
+        if (error) console.warn("Could not move " + ids[i] + ": " + error)
+      }
+    }
+  }
+
   function barStateFor(id) {
     var reg = root.registry
     var config = reg && typeof reg.shellConfigProvider === "function"
@@ -1505,6 +1562,24 @@ Panel {
                 verticalPadding: Style.space(3)
                 Layout.alignment: Qt.AlignVCenter
                 onClicked: Qt.openUrlExternally("https://plugins.omarchy.org")
+              }
+
+              Button {
+                id: reorderBarButton
+                text: "\uf0dc  Reorder bar"
+                tooltipText: "Drag and drop to reorder the widgets on the bar"
+                bordered: true
+                foreground: root.contentForeground
+                accent: Color.accent
+                fontFamily: root.contentFontFamily
+                fontSize: Style.font.caption
+                horizontalPadding: Style.space(8)
+                verticalPadding: Style.space(3)
+                Layout.alignment: Qt.AlignVCenter
+                onClicked: {
+                  root.reorderLayoutSnapshot = root.currentBarLayout()
+                  root.reorderDialogOpen = true
+                }
               }
 
               Button {
@@ -1902,6 +1977,23 @@ Panel {
 
       onCancelRequested: root.cancelInstallConfirm()
       onConfirmRequested: root.installPlugin()
+    }
+
+    Dialogs.Reorder {
+      anchors.fill: parent
+      z: 12000
+
+      open: root.reorderDialogOpen
+      layout: root.reorderLayoutSnapshot
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
+
+      onCloseRequested: root.reorderDialogOpen = false
+      onSaveRequested: function(order) {
+        root.applyBarOrder(order)
+        root.reorderDialogOpen = false
+      }
     }
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -1306,6 +1306,12 @@ Panel {
   // persisted the same way. Placing ids in ascending target-index order
   // converges to the exact desired permutation in one pass regardless of
   // where an id currently sits, including across sections.
+  //
+  // Only widgets whose (section, index) actually changed get a moveBarWidget
+  // call: each call live-reflows the real bar (this plugin's own toggle icon
+  // included), so calling it for entries that never moved was churning that
+  // reflow once per widget on the whole bar for no reason - including once
+  // Save had nothing left to apply.
   function applyBarOrder(order) {
     var reg = root.registry
     if (!reg || typeof reg.moveBarWidget !== "function" || !order) return
@@ -1313,8 +1319,11 @@ Panel {
     for (var s = 0; s < sections.length; s++) {
       var ids = Array.isArray(order[sections[s]]) ? order[sections[s]] : []
       for (var i = 0; i < ids.length; i++) {
-        var error = reg.moveBarWidget(String(ids[i]), { section: sections[s], index: i })
-        if (error) console.warn("Could not move " + ids[i] + ": " + error)
+        var id = String(ids[i])
+        var current = root.barStateFor(id)
+        if (current && current.section === sections[s] && current.index === i) continue
+        var error = reg.moveBarWidget(id, { section: sections[s], index: i })
+        if (error) console.warn("Could not move " + id + ": " + error)
       }
     }
   }
@@ -1988,8 +1997,10 @@ Panel {
 
       onCloseRequested: root.reorderDialogOpen = false
       onSaveRequested: function(order) {
-        root.applyBarOrder(order)
+        // Close first, apply after: applyBarOrder() live-reflows the real
+        // bar, so run it once this popup is no longer the thing on screen.
         root.reorderDialogOpen = false
+        Qt.callLater(function() { root.applyBarOrder(order) })
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Omaplug is listed on the marketplace: [plugins.omarchy.org/plugin.html?id=omaplu
 ## What it can do
 
 - **🔌 Enable / disable** — every discovered plugin (Omarchy's own and third-party) gets a simple toggle. Flipping it goes through the same registry the `omarchy plugin enable/disable` command uses, so what you see here is always what's really running.
+- **↕️ Reorder the bar** — drag widgets to reorder them within a section, or between the left/center/right sections, with a live preview. Nothing changes on the bar until you hit Save — no restart needed, it applies instantly.
 - **🔄 Check for updates** — scans every installed third-party plugin and distinguishes clean updates from local plugins, symlinked development plugins, local changes, and genuine fetch errors.
 - **⬆️ Update (or update everything)** — apply one update, or finish every proven-safe pending update from a single click, even while Omarchy reloads changed plugins.
 - **➕ Install** — paste a git repo URL and add a plugin in one step. It'll warn you first that plugins run as unsandboxed code, because honesty is the default here.

--- a/panel/dialogs/Reorder.qml
+++ b/panel/dialogs/Reorder.qml
@@ -1,0 +1,429 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Drag-and-drop bar reorder popup. Widgets are grouped into the three bar
+// sections (left/center/right); a row can be dragged within its column to
+// reorder, or across columns to relocate. Nothing touches the registry while
+// dragging — leftItems/centerItems/rightItems only get reassigned once, on
+// drop, so a mid-gesture reassignment never destroys the delegate whose
+// MouseArea is holding the mouse grab. Save hands the final per-section id
+// order up to Panel.qml, which is the only thing that talks to the registry.
+Rectangle {
+  id: dialog
+
+  required property bool open
+  required property var layout // { left: [{widgetId,label,icon}], center: [...], right: [...] }
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  signal closeRequested
+  signal saveRequested(var order)
+
+  readonly property real rowHeight: Style.space(34)
+
+  property var leftItems: []
+  property var centerItems: []
+  property var rightItems: []
+
+  property bool dragActive: false
+  property string dragWidgetId: ""
+  property string dragLabel: ""
+  property string dragIcon: ""
+  property string dragFromSection: ""
+  property int dragFromIndex: -1
+  property string dragTargetSection: ""
+  property int dragTargetIndex: -1
+
+  visible: open
+  color: Util.alpha(panelBackground, 0.7)
+  focus: true
+  Keys.priority: Keys.BeforeItem
+  Keys.onEscapePressed: dialog.closeRequested()
+
+  function itemsFor(section) {
+    if (section === "left") return dialog.leftItems
+    if (section === "center") return dialog.centerItems
+    return dialog.rightItems
+  }
+
+  function setItemsFor(section, arr) {
+    if (section === "left") dialog.leftItems = arr
+    else if (section === "center") dialog.centerItems = arr
+    else dialog.rightItems = arr
+  }
+
+  function resetFromLayout() {
+    var src = dialog.layout || {}
+    dialog.leftItems = Array.isArray(src.left) ? src.left.slice() : []
+    dialog.centerItems = Array.isArray(src.center) ? src.center.slice() : []
+    dialog.rightItems = Array.isArray(src.right) ? src.right.slice() : []
+  }
+
+  onOpenChanged: {
+    if (open) {
+      dialog.resetFromLayout()
+    } else {
+      dialog.dragActive = false
+      dialog.dragWidgetId = ""
+    }
+  }
+
+  function columnAt(x) {
+    var cols = [
+      { name: "left", item: leftColumn },
+      { name: "center", item: centerColumn },
+      { name: "right", item: rightColumn }
+    ]
+    for (var i = 0; i < cols.length; i++) {
+      var it = cols[i].item
+      if (x >= it.x && x < it.x + it.width) return cols[i].name
+    }
+    return x < centerColumn.x ? "left" : "right"
+  }
+
+  function indexAt(section, y) {
+    var listItem = section === "left" ? leftRowsList : (section === "center" ? centerRowsList : rightRowsList)
+    var origin = listItem.mapToItem(columnsRow, 0, 0)
+    var arr = dialog.itemsFor(section)
+    var virtualLength = arr.length - (section === dialog.dragFromSection ? 1 : 0)
+    var localY = y - origin.y
+    var idx = Math.round(localY / dialog.rowHeight)
+    return Math.max(0, Math.min(virtualLength, idx))
+  }
+
+  // Visual slot for a row that is NOT the one being dragged: its index
+  // within "the array with the dragged item removed from its origin and
+  // reinserted at the current drag target", computed analytically so other
+  // rows only need their own (section, index) — no array rebuild per frame.
+  function previewY(section, index, widgetId) {
+    var base = index * dialog.rowHeight
+    if (!dialog.dragActive || widgetId === dialog.dragWidgetId) return base
+    var v = index
+    if (section === dialog.dragFromSection && index > dialog.dragFromIndex) v -= 1
+    if (section === dialog.dragTargetSection && v >= dialog.dragTargetIndex) v += 1
+    return v * dialog.rowHeight
+  }
+
+  function startDrag(section, index, widgetId, label, icon, pos) {
+    dialog.dragActive = true
+    dialog.dragWidgetId = widgetId
+    dialog.dragLabel = label
+    dialog.dragIcon = icon
+    dialog.dragFromSection = section
+    dialog.dragFromIndex = index
+    dialog.dragTargetSection = section
+    dialog.dragTargetIndex = index
+    ghost.x = pos.x - ghost.width / 2
+    ghost.y = pos.y - ghost.height / 2
+  }
+
+  function updateDrag(pos) {
+    if (!dialog.dragActive) return
+    ghost.x = pos.x - ghost.width / 2
+    ghost.y = pos.y - ghost.height / 2
+    var section = dialog.columnAt(pos.x)
+    dialog.dragTargetSection = section
+    dialog.dragTargetIndex = dialog.indexAt(section, pos.y)
+  }
+
+  function endDrag() {
+    if (dialog.dragActive && dialog.dragWidgetId !== "") {
+      var fromArr = dialog.itemsFor(dialog.dragFromSection).slice()
+      var draggedItem = fromArr.splice(dialog.dragFromIndex, 1)[0]
+      if (draggedItem) {
+        if (dialog.dragTargetSection === dialog.dragFromSection) {
+          fromArr.splice(dialog.dragTargetIndex, 0, draggedItem)
+          dialog.setItemsFor(dialog.dragFromSection, fromArr)
+        } else {
+          dialog.setItemsFor(dialog.dragFromSection, fromArr)
+          var targetArr = dialog.itemsFor(dialog.dragTargetSection).slice()
+          targetArr.splice(dialog.dragTargetIndex, 0, draggedItem)
+          dialog.setItemsFor(dialog.dragTargetSection, targetArr)
+        }
+      }
+    }
+    dialog.dragActive = false
+    dialog.dragWidgetId = ""
+    dialog.dragFromSection = ""
+    dialog.dragFromIndex = -1
+    dialog.dragTargetSection = ""
+    dialog.dragTargetIndex = -1
+  }
+
+  function collectOrder() {
+    return {
+      left: dialog.leftItems.map(function(it) { return it.widgetId }),
+      center: dialog.centerItems.map(function(it) { return it.widgetId }),
+      right: dialog.rightItems.map(function(it) { return it.widgetId })
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    onClicked: dialog.closeRequested()
+  }
+
+  Rectangle {
+    id: card
+
+    anchors.centerIn: parent
+    width: Math.min(parent.width - Style.space(32), Style.space(640))
+    height: Math.min(parent.height - Style.space(64), cardContent.implicitHeight + Style.space(36))
+    color: dialog.panelBackground
+    radius: Style.cornerRadius
+    border.color: Style.selectedStateColor(dialog.foreground, Color.accent)
+    border.width: 1
+
+    ColumnLayout {
+      id: cardContent
+
+      anchors.fill: parent
+      anchors.margins: Style.space(18)
+      spacing: Style.space(12)
+
+      Text {
+        text: "Reorder the bar"
+        textFormat: Text.PlainText
+        color: dialog.foreground
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.title
+        font.bold: true
+        Layout.fillWidth: true
+      }
+
+      Text {
+        text: "Drag a widget to reorder it, or drag it into another column to move it there. Nothing changes on the bar until you save."
+        textFormat: Text.PlainText
+        color: Qt.darker(dialog.foreground, 1.6)
+        font.family: dialog.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+      }
+
+      Item {
+        id: columnsRow
+        Layout.fillWidth: true
+        Layout.preferredHeight: Math.max(
+          dialog.leftItems.length, dialog.centerItems.length, dialog.rightItems.length, 1
+        ) * dialog.rowHeight + Style.space(28)
+
+        readonly property real columnSpacing: Style.space(10)
+        readonly property real columnWidth: (columnsRow.width - columnSpacing * 2) / 3
+
+        ColumnLayout {
+          id: leftColumn
+          x: 0
+          width: columnsRow.columnWidth
+          height: parent.height
+          spacing: Style.space(6)
+
+          Label {
+            text: "Left"
+            color: Qt.darker(dialog.foreground, 1.4)
+            font.family: dialog.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+          }
+
+          Item {
+            id: leftRowsList
+            Layout.fillWidth: true
+            Layout.preferredHeight: dialog.leftItems.length * dialog.rowHeight
+
+            Repeater {
+              model: dialog.leftItems
+              delegate: ReorderRow {
+                required property var modelData
+                required property int index
+                width: leftRowsList.width
+                height: dialog.rowHeight
+                y: dialog.previewY("left", index, modelData.widgetId)
+                widgetId: modelData.widgetId
+                label: modelData.label
+                icon: modelData.icon
+                dragging: dialog.dragActive && dialog.dragWidgetId === modelData.widgetId
+                foreground: dialog.foreground
+                fontFamily: dialog.fontFamily
+                onDragPressed: function(pos) {
+                  dialog.startDrag("left", index, modelData.widgetId, modelData.label, modelData.icon, pos)
+                }
+                onDragMoved: function(pos) { dialog.updateDrag(pos) }
+                onDragEnded: dialog.endDrag()
+                mapTarget: columnsRow
+              }
+            }
+          }
+
+          Item { Layout.fillHeight: true }
+        }
+
+        ColumnLayout {
+          id: centerColumn
+          x: leftColumn.width + columnsRow.columnSpacing
+          width: columnsRow.columnWidth
+          height: parent.height
+          spacing: Style.space(6)
+
+          Label {
+            text: "Center"
+            color: Qt.darker(dialog.foreground, 1.4)
+            font.family: dialog.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+          }
+
+          Item {
+            id: centerRowsList
+            Layout.fillWidth: true
+            Layout.preferredHeight: dialog.centerItems.length * dialog.rowHeight
+
+            Repeater {
+              model: dialog.centerItems
+              delegate: ReorderRow {
+                required property var modelData
+                required property int index
+                width: centerRowsList.width
+                height: dialog.rowHeight
+                y: dialog.previewY("center", index, modelData.widgetId)
+                widgetId: modelData.widgetId
+                label: modelData.label
+                icon: modelData.icon
+                dragging: dialog.dragActive && dialog.dragWidgetId === modelData.widgetId
+                foreground: dialog.foreground
+                fontFamily: dialog.fontFamily
+                onDragPressed: function(pos) {
+                  dialog.startDrag("center", index, modelData.widgetId, modelData.label, modelData.icon, pos)
+                }
+                onDragMoved: function(pos) { dialog.updateDrag(pos) }
+                onDragEnded: dialog.endDrag()
+                mapTarget: columnsRow
+              }
+            }
+          }
+
+          Item { Layout.fillHeight: true }
+        }
+
+        ColumnLayout {
+          id: rightColumn
+          x: (leftColumn.width + columnsRow.columnSpacing) * 2
+          width: columnsRow.columnWidth
+          height: parent.height
+          spacing: Style.space(6)
+
+          Label {
+            text: "Right"
+            color: Qt.darker(dialog.foreground, 1.4)
+            font.family: dialog.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+          }
+
+          Item {
+            id: rightRowsList
+            Layout.fillWidth: true
+            Layout.preferredHeight: dialog.rightItems.length * dialog.rowHeight
+
+            Repeater {
+              model: dialog.rightItems
+              delegate: ReorderRow {
+                required property var modelData
+                required property int index
+                width: rightRowsList.width
+                height: dialog.rowHeight
+                y: dialog.previewY("right", index, modelData.widgetId)
+                widgetId: modelData.widgetId
+                label: modelData.label
+                icon: modelData.icon
+                dragging: dialog.dragActive && dialog.dragWidgetId === modelData.widgetId
+                foreground: dialog.foreground
+                fontFamily: dialog.fontFamily
+                onDragPressed: function(pos) {
+                  dialog.startDrag("right", index, modelData.widgetId, modelData.label, modelData.icon, pos)
+                }
+                onDragMoved: function(pos) { dialog.updateDrag(pos) }
+                onDragEnded: dialog.endDrag()
+                mapTarget: columnsRow
+              }
+            }
+          }
+
+          Item { Layout.fillHeight: true }
+        }
+
+        Rectangle {
+          id: ghost
+          visible: dialog.dragActive
+          z: 10000
+          width: Style.space(160)
+          height: dialog.rowHeight
+          radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
+          color: Style.hoverFillFor(dialog.foreground, Color.accent)
+          border.color: Color.accent
+          border.width: 1
+          opacity: 0.92
+
+          RowLayout {
+            anchors.fill: parent
+            anchors.margins: Style.space(6)
+            spacing: Style.space(6)
+
+            Text {
+              text: dialog.dragIcon
+              textFormat: Text.PlainText
+              color: dialog.foreground
+              font.family: dialog.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              visible: dialog.dragIcon !== ""
+            }
+
+            Label {
+              text: dialog.dragLabel
+              textFormat: Text.PlainText
+              color: dialog.foreground
+              font.family: dialog.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              elide: Label.ElideRight
+              Layout.fillWidth: true
+            }
+          }
+        }
+      }
+
+      RowLayout {
+        Layout.fillWidth: true
+
+        Item { Layout.fillWidth: true }
+
+        Button {
+          text: "Cancel"
+          foreground: dialog.foreground
+          accent: Color.accent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.closeRequested()
+        }
+
+        Button {
+          text: "Save"
+          foreground: dialog.foreground
+          accent: Color.accent
+          fontFamily: dialog.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(12)
+          verticalPadding: Style.space(6)
+          onClicked: dialog.saveRequested(dialog.collectOrder())
+        }
+      }
+    }
+  }
+}

--- a/panel/dialogs/ReorderRow.qml
+++ b/panel/dialogs/ReorderRow.qml
@@ -1,0 +1,81 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// One draggable row inside the Reorder popup. Reports press/move/release in
+// `mapTarget`-local coordinates and lets the popup own all reorder state —
+// this row never mutates a model itself, so it can be safely left alone
+// mid-drag (see Reorder.qml's header comment for why that matters).
+Item {
+  id: row
+
+  required property string widgetId
+  required property string label
+  required property string icon
+  required property bool dragging
+  required property color foreground
+  required property string fontFamily
+  required property Item mapTarget
+
+  signal dragPressed(var pos)
+  signal dragMoved(var pos)
+  signal dragEnded
+
+  opacity: dragging ? 0.35 : 1
+  Behavior on y { enabled: !row.dragging; NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+
+  Rectangle {
+    anchors.fill: parent
+    anchors.margins: Style.space(2)
+    radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
+    color: hover.hovered ? Style.hoverFillFor(row.foreground, Color.accent) : "transparent"
+
+    RowLayout {
+      anchors.fill: parent
+      anchors.leftMargin: Style.space(8)
+      anchors.rightMargin: Style.space(8)
+      spacing: Style.space(6)
+
+      Text {
+        text: row.icon
+        textFormat: Text.PlainText
+        color: row.foreground
+        font.family: row.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        visible: row.icon !== ""
+        Layout.preferredWidth: Style.space(18)
+      }
+
+      Label {
+        text: row.label
+        textFormat: Text.PlainText
+        color: row.foreground
+        font.family: row.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        elide: Label.ElideRight
+        Layout.fillWidth: true
+      }
+    }
+
+    HoverHandler { id: hover }
+
+    MouseArea {
+      id: mouseArea
+      anchors.fill: parent
+      preventStealing: true
+      cursorShape: row.dragging ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+      onPressed: function(mouse) {
+        row.dragPressed(mouseArea.mapToItem(row.mapTarget, mouse.x, mouse.y))
+      }
+      onPositionChanged: function(mouse) {
+        if (row.dragging) row.dragMoved(mouseArea.mapToItem(row.mapTarget, mouse.x, mouse.y))
+      }
+      onReleased: row.dragEnded()
+      onCanceled: row.dragEnded()
+    }
+  }
+}

--- a/panel/dialogs/ReorderRow.qml
+++ b/panel/dialogs/ReorderRow.qml
@@ -25,7 +25,13 @@ Item {
   signal dragMoved(var pos)
   signal dragEnded
 
-  opacity: dragging ? 0.35 : 1
+  // Fully hidden (not just dimmed) while dragging: it stays parked at its
+  // original index for the duration of the gesture (see Reorder.qml's
+  // previewY), and other rows sliding into "the gap it left" during the
+  // live preview can land on that exact slot — dimming would show both
+  // texts overlapping there. The floating ghost plus the gap in the list
+  // are enough feedback without it being visible too.
+  opacity: dragging ? 0 : 1
   Behavior on y { enabled: !row.dragging; NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
 
   Rectangle {


### PR DESCRIPTION
## Summary

Adds a "Reorder bar" popup to the plugin manager panel: drag a widget to reorder it within its section (left/center/right), or drag it across sections to relocate it, with a live preview. Nothing changes on the actual bar until you hit Save — Save then applies the new order through the registry's `moveBarWidget`, the same primitive `omarchy bar move` and this plugin's own enable/disable already use, so the change takes effect and persists immediately with no shell restart required.

- **Popup UI** (`panel/dialogs/Reorder.qml`, `panel/dialogs/ReorderRow.qml`): three columns (Left/Center/Right) of draggable rows, a floating ghost that follows the cursor, and a live index preview so other rows visibly slide into the gap while dragging. The dragged row is fully hidden (not just dimmed) for the duration of the gesture, since it stays parked at its original index and other rows can slide into that exact slot during the preview — dimming would show overlapping text there.
- **Entry point**: a "Reorder bar" button sits in the panel's icon-only header row, next to the other icon actions.
- **Applying the order**: `Panel.qml` snapshots the current bar layout when the popup opens, collects the edited per-section id order on Save, and only calls `moveBarWidget` for widgets whose section/index actually changed — an unconditional call for every widget on the bar would reflow the whole thing (including this plugin's own toggle icon, since "Plugin Manager" is itself one of the reorderable widgets) for entries that never moved, including when Save has nothing to apply at all.
- **Save ordering**: the popup closes first, and the bar reorder is applied afterward (`Qt.callLater`), rather than live-reflowing the bar while the popup is still on screen.

## Known issue (not fixed here, root cause is outside this repo)

While building this, right after clicking Save the whole panel would flash to the screen's top-left corner for a frame before closing. Recorded the interaction and stepped through it frame-by-frame, which first pointed at the bar's live reflow racing the popup's close — hence the no-op-skipping and save-ordering changes above.

A second recording taken after those changes — with zero actual widget moves to apply, so `moveBarWidget` never even fires — still showed the same flash. That rules out this repo's code and traces the glitch to a fallback in the shell's own `Ui/KeyboardPanel.qml` (`cardOrigin`'s `if (!anchorItem || !bar) return Qt.point(margin, margin)`), which the popup card's position is bound to for the whole 140ms it stays visible while closing. Fixing that needs a change upstream in the Omarchy shell, not in omaplug.

## Test plan
- [x] Open the bar-reorder popup, drag a widget within a section, Save — new order takes effect on the bar immediately.
- [x] Drag a widget across sections (e.g. center → right), Save — widget moves section and persists after a shell restart.
- [x] Open the popup and Save with no changes — no widgets on the bar should reflow.
- [x] Cancel / Escape closes the popup without changing the bar.
- [x] "Reorder bar" button appears in the icon row; dragging a row shows no overlapping labels in the live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)