### PR TITLE
fix: keep Screen Time update icon stable

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -318,12 +318,10 @@ Panel {
   }
 
   function iconFor(id) {
-    // The clock widget's live button text is the current time, which reads
-    // like noise as a row icon — always show the clock glyph for it instead.
-    if (/clock/i.test(String(id))) return "\uf017"
-    var live = root.liveGlyphFor(id)
-    if (live && root.isStandaloneGlyph(live)) return live
+    // Screen Time puts a changing duration in its bar-button text. A row icon
+    // must be stable, so use its dedicated glyph instead of that live label.
     var map = {
+      "agx.screen-time":    "\udb81\udd1f",
       "omaplug":            "\udb85\udcd9",
       "adna.bar":            "\uf2f2",
       "adna.bar-switch":     "\uf2f2",
@@ -356,6 +354,9 @@ Panel {
       "omarchy.polkit":      "\uf3ed",
       "omarchy.reminders":   "\uf017"
     }
+    if (id === "agx.screen-time" || /clock/i.test(String(id))) return map[id] || "\uf017"
+    var live = root.liveGlyphFor(id)
+    if (live && root.isStandaloneGlyph(live)) return live
     return map[id] || ""
   }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,4 +7,4 @@ ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 "$ROOT/plugin-state-test.sh"
 "$ROOT/update-helper-test.sh"
 "$ROOT/quickshell-detached-test.sh"
-"$ROOT/verification-status-test.sh"
+bash "$ROOT/verification-status-test.sh"

--- a/tests/verification-status-test.sh
+++ b/tests/verification-status-test.sh
@@ -23,5 +23,7 @@ assert_contains 'marketplaceMap: root.marketplaceMap' "$PANEL"
 assert_contains 'marketplaceFetching: root.marketplaceFetching' "$PANEL"
 assert_contains 'marketplaceFetchFailed: root.marketplaceFetchFailed' "$PANEL"
 assert_contains '"--max-filesize", "8388608"' "$PANEL"
+assert_contains '"agx.screen-time":    "\udb81\udd1f"' "$PANEL"
+assert_contains 'id === "agx.screen-time"' "$PANEL"
 
 printf 'verification-status-test: ok\n'


### PR DESCRIPTION
## Summary
- render Screen Time's static Nerd Font glyph in the updates list
- prevent its live duration label (for example `1h 7m`) from overflowing the icon tile
- run the verification script via Bash so the test suite works in checkouts preserving its non-executable file mode

## Test
- `./tests/run.sh`