### PR TITLE
fix: keep live widget labels out of plugin icons

### DIFF
--- a/tests/icon-glyph-test.sh
+++ b/tests/icon-glyph-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PANEL="$ROOT/Panel.qml"
+
+node - "$PANEL" <<'NODE'
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+
+const panel = fs.readFileSync(process.argv[2], "utf8")
+const start = panel.indexOf("  function isStandaloneGlyph(text) {")
+const end = panel.indexOf("\n  function iconFor(id) {", start)
+assert.ok(start >= 0 && end > start, "isStandaloneGlyph must be present in Panel.qml")
+assert.ok(panel.includes("if (live && root.isStandaloneGlyph(live)) return live"),
+  "iconFor must guard live labels with isStandaloneGlyph")
+
+const source = panel.slice(start, end).replace(/^  /gm, "")
+const isStandaloneGlyph = new Function(`${source}\nreturn isStandaloneGlyph`)()
+
+assert.equal(isStandaloneGlyph("\uf0f3"), true)
+assert.equal(isStandaloneGlyph("\udb85\udcd9"), true)
+assert.equal(isStandaloneGlyph("\uf0f3 1h 58m"), false)
+assert.equal(isStandaloneGlyph("1h 58m"), false)
+assert.equal(isStandaloneGlyph("12345"), false)
+
+console.log("icon-glyph-test: ok")
+NODE

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,3 +9,4 @@ ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 "$ROOT/quickshell-detached-test.sh"
 bash "$ROOT/verification-status-test.sh"
 node "$ROOT/plugin-metadata-test.cjs"
+bash "$ROOT/icon-glyph-test.sh"


### PR DESCRIPTION
## Summary
- keep only the leading Nerd Font glyph from a bar widget label
- prevent durations, counters, temperatures, and other live text from overflowing fixed-size plugin icon tiles
- retain mapped icons or initials when a widget has no usable glyph

## Test
- `./tests/run.sh`
- verified locally in the running Omarchy shell

## Screenshots

Reported rendering issue:

<img width="698" alt="Plugin updates list showing live widget text overflowing an icon tile" src="https://github.com/user-attachments/assets/68e445bf-26b0-4f9f-98c8-367cbb62cc2e" />

Focused example:

<img width="696" alt="Screen Time row showing the dynamic duration inside its icon tile" src="https://github.com/user-attachments/assets/b343520d-b4f2-44ab-bd45-a152ebc14fe0" />