### PR TITLE
feat(panel): bar-widget placement — row-menu move, keep-open, drag-and-drop layout board

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1536,8 +1536,7 @@ Panel {
     // A toggle/move/remove rewrites shell.json, and the bar rebuilds every
     // widget on every monitor in response — including this panel's own
     // Loader, which destroys the open instance. Consume a pending reopen
-    // flag (state file) so the fresh instance reopens itself.
-    keepOpenFlagRead.running = true
+    // flag (state file) so the fresh instance reopens itself.    keepOpenFlagRead.running = true
   }
 
   // Mark the panel to reopen after the bar rebuild that this action is

--- a/Panel.qml
+++ b/Panel.qml
@@ -1612,6 +1612,7 @@ Panel {
     else root.open()
   }
 
+
   function switchPanel(direction) {
     if (root.bar && typeof root.bar.switchPanelFrom === "function")
       return root.bar.switchPanelFrom(root.barIdentity, direction)

--- a/Panel.qml
+++ b/Panel.qml
@@ -211,6 +211,7 @@ Panel {
   property var removeSelection: ({})
   property bool removeSelectMode: false
   property string removeSummary: ""
+  property string moveSummary: ""
   property var removeQueue: []
   property bool removingPlugin: false
   property bool removeConfirmOpen: false
@@ -1393,6 +1394,133 @@ Panel {
     return false
   }
 
+  // Bar-widget placement via the same CLI the bar group uses. Upstream
+  // drives enable/disable through `omarchy plugin …` subprocesses, so move
+  // follows the same pattern with `omarchy bar move` instead of touching
+  // the shell registry (which user panels no longer reach).
+  property var barLayoutCache: ({ left: [], center: [], right: [] })
+  property Process barLayoutProcess: Process {
+    onExited: function(exitCode) {
+      if (exitCode === 0) root.applyBarLayout(barLayoutStdout.text)
+    }
+    stdout: StdioCollector {
+      id: barLayoutStdout
+      waitForEnd: true
+    }
+  }
+  property Process barMoveProcess: Process {
+    onExited: function(exitCode) {
+      var err = String(barMoveStdout.text || "").trim()
+      if (exitCode !== 0) {
+        root.moveSummary = "Move failed" + (err ? ": " + err : "")
+      } else if (root.movePending !== "") {
+        root.moveSummary = "Moved " + root.movePending + "."
+      }
+      root.movePending = ""
+      root.refreshBarLayout()
+      root.refreshPlugins()
+    }
+    stdout: StdioCollector {
+      id: barMoveStdout
+      waitForEnd: true
+    }
+  }
+  property string movePending: ""
+
+  function refreshBarLayout() {
+    if (root.barLayoutProcess.running) return
+    root.barLayoutProcess.command = ["bash", "-c", "cat \"${XDG_CONFIG_HOME:-$HOME/.config}/omarchy/shell.json\""]
+    root.barLayoutProcess.running = true
+  }
+
+  function applyBarLayout(text) {
+    var config
+    try { config = JSON.parse(String(text || "")) }
+    catch (e) {
+      console.warn("Could not parse shell.json for bar layout:", e)
+      return
+    }
+    var layout = config && config.bar ? config.bar.layout : null
+    var next = { left: [], center: [], right: [] }
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var entries = layout && Array.isArray(layout[sections[s]]) ? layout[sections[s]] : []
+      var ids = []
+      for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i]
+        var id = entry && typeof entry === "object" ? entry.id : entry
+        if (id) ids.push(String(id))
+      }
+      next[sections[s]] = ids
+    }
+    root.barLayoutCache = next
+  }
+
+  // Move state for the row-menu "Move to" actions. Only bar-widgets that are
+  // currently on the bar can move; anything else hides the menu entries.
+  function barSectionFor(id) {
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var ids = root.barLayoutCache[sections[s]] || []
+      if (ids.indexOf(String(id)) !== -1) return sections[s]
+    }
+    return ""
+  }
+
+  function rowKinds(id) {
+    for (var i = 0; i < root.pluginRows.length; i++)
+      if (root.pluginRows[i].id === String(id)) return String(root.pluginRows[i].kinds || "")
+    return ""
+  }
+
+  function rowName(id) {
+    for (var i = 0; i < root.pluginRows.length; i++)
+      if (root.pluginRows[i].id === String(id)) return String(root.pluginRows[i].name || id)
+    return String(id)
+  }
+
+  function canMoveWidget(id) {
+    if (rowKinds(id).split(", ").indexOf("bar-widget") === -1) return false
+    return root.barSectionFor(id) !== ""
+  }
+
+  function moveWidgetToSection(id, section) {
+    if (["left", "center", "right"].indexOf(section) === -1) return
+    if (root.barMoveProcess.running) return
+    if (root.barSectionFor(id) === section) return
+    root.keepOpenAcrossRebuild()
+    root.movePending = id + " to " + section
+    root.moveSummary = "Moving " + id + "…"
+    root.barMoveProcess.command = ["omarchy", "bar", "move", id, "--section", section]
+    root.barMoveProcess.running = true
+  }
+
+  function moveWidgetToPosition(id, section, index) {
+    if (["left", "center", "right"].indexOf(section) === -1) return
+    if (root.barMoveProcess.running) return
+    root.keepOpenAcrossRebuild()
+    var target = Math.max(0, Math.floor(Number(index) || 0))
+    root.movePending = id + " to " + section
+    root.moveSummary = "Moving " + id + "…"
+    root.barMoveProcess.command = ["omarchy", "bar", "move", id, "--section", section, "--index", String(target)]
+    root.barMoveProcess.running = true
+  }
+
+  // Live bar layout grouped per section for the layout board.
+  function layoutSections() {
+    var out = []
+    var sections = ["left", "center", "right"]
+    for (var s = 0; s < sections.length; s++) {
+      var ids = root.barLayoutCache[sections[s]] || []
+      var items = []
+      for (var i = 0; i < ids.length; i++) {
+        items.push({ id: ids[i], name: root.rowName(ids[i]) })
+      }
+      out.push({ section: sections[s], entries: items })
+    }
+    return out
+  }
+
   Component.onCompleted: {
     console.log("Panel.qml loaded, filterMode=", root.filterMode, "rows=", root.pluginRows.length)
     root.updateHelperPath = String(Qt.resolvedUrl("plugin-state.sh")).replace(/^file:\/\//, "")
@@ -1408,10 +1536,17 @@ Panel {
     refreshPlugins()
     // Pick up verification changes while retaining cached badges during the fetch.
     fetchMarketplace()
+    root.refreshBarLayout()
     root.controller.show()
     Qt.callLater(function() {
       if (root.opened) root.primeFocus()
     })
+  }
+
+  // Reopen marker so the panel stays on top across the bar rebuild that a
+  // move triggers. (Full keep-open machinery arrives in a later commit;
+  // this stub keeps this commit working on its own.)
+  function keepOpenAcrossRebuild() {
   }
 
   function close() {
@@ -1761,6 +1896,7 @@ Panel {
           spacing: Style.space(8)
           Layout.maximumHeight: implicitHeight
           visible: root.updateSummary !== "" || root.removeSummary !== ""
+            || root.moveSummary !== ""
             || (root.removeSelectMode && root.selectedRemoveCount > 0)
 
           Label {
@@ -1775,6 +1911,15 @@ Panel {
           Label {
             visible: root.removeSummary !== ""
             text: root.removeSummary
+            textFormat: Text.PlainText
+            color: Style.selectedStateColor(root.contentForeground, Color.accent)
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+
+          Label {
+            visible: root.moveSummary !== ""
+            text: root.moveSummary
             textFormat: Text.PlainText
             color: Style.selectedStateColor(root.contentForeground, Color.accent)
             font.family: root.contentFontFamily
@@ -1850,6 +1995,8 @@ Panel {
       foreground: root.contentForeground
       fontFamily: root.contentFontFamily
       panelBackground: root.panelBackground
+      canMove: rowMenuOverlay.plugin ? root.canMoveWidget(rowMenuOverlay.plugin.id) : false
+      currentSection: rowMenuOverlay.plugin ? root.barSectionFor(rowMenuOverlay.plugin.id) : ""
 
       onCloseRequested: root.closeRowMenu()
       onEnabledChangeRequested: function(pluginId, enabled) {
@@ -1858,6 +2005,7 @@ Panel {
       onSourceRequested: function(sourceKey) { root.openPluginRepo(sourceKey) }
       onUpdateRequested: function(sourceKey) { root.updatePlugin(sourceKey) }
       onRemovalRequested: function(pluginId) { root.removePlugin(pluginId) }
+      onMoveRequested: function(pluginId, section) { root.moveWidgetToSection(pluginId, section) }
     }
 
     Dialogs.Confirm {

--- a/Panel.qml
+++ b/Panel.qml
@@ -9,6 +9,7 @@ import qs.Commons
 import qs.Ui
 import "panel/Presentation.js" as Presentation
 import "panel/dialogs" as Dialogs
+import "panel/layout" as Arrange
 import "panel/plugin" as Plugin
 import "panel/updates" as Updates
 
@@ -220,6 +221,9 @@ Panel {
   // relaunches the shell so plugins reload from source (fixes stale compiled
   // plugin QML that a live rescan would keep serving).
   property bool restartConfirmOpen: false
+  // Bar-layout board (drag-and-drop ordering across left/center/right).
+  property bool layoutPageOpen: false
+  readonly property var barLayoutSections: root.layoutSections()
   // Right-click context menu on a main-page row.
   property bool rowMenuOpen: false
   property string rowMenuId: ""
@@ -449,6 +453,7 @@ Panel {
   }
 
   function confirmRemove() {
+    root.keepOpenAcrossRebuild()
     root.removeQueue = root.removePending.slice()
     root.removePending = []
     root.removeConfirmOpen = false
@@ -1371,8 +1376,7 @@ Panel {
         sourceKey: row.sourceKey,
         updatable: row.updatable,
         enabled: row.enabled
-      })
-    }
+      })    }
     root.pluginRows = rows
   }
 
@@ -1384,6 +1388,7 @@ Panel {
       var row = root.pluginRows[i]
       if (row.id === id && value === false && row.canDisable === false) return
     }
+    root.keepOpenAcrossRebuild()
     root.pluginToggleProcess.command = ["omarchy", "plugin", value ? "enable" : "disable", id]
     root.pluginToggleProcess.running = true
   }
@@ -1528,6 +1533,54 @@ Panel {
     refreshPlugins()
     fetchMarketplace()
     Qt.callLater(function() { updateStatusFile.reload() })
+    // A toggle/move/remove rewrites shell.json, and the bar rebuilds every
+    // widget on every monitor in response — including this panel's own
+    // Loader, which destroys the open instance. Consume a pending reopen
+    // flag (state file) so the fresh instance reopens itself.
+    keepOpenFlagRead.running = true
+  }
+
+  // Mark the panel to reopen after the bar rebuild that this action is
+  // about to trigger. Call before any registry write from panel UI.
+  // The flag lives in a state file: instance properties cannot survive the
+  // rebuild, and the shell object rejects dynamic properties.
+  function keepOpenAcrossRebuild() {
+    keepOpenFlagWrite.running = true
+  }
+
+  // State-file flag backing keepOpenAcrossRebuild. Two one-shot Processes
+  // (write before the action, consume on fresh load) because plain file IO
+  // from QML JS is intentionally unavailable in Quickshell.
+  Process {
+    id: keepOpenFlagWrite
+    command: ["bash", "-c", "mkdir -p \"${XDG_STATE_HOME:-$HOME/.local/state}/omarchy\" && touch \"${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/omaplug-keep-open\""]
+  }
+
+  Process {
+    id: keepOpenFlagRead
+    command: ["bash", "-c", "f=\"${XDG_STATE_HOME:-$HOME/.local/state}/omarchy/omaplug-keep-open\"; if [ -f \"$f\" ]; then rm -f \"$f\"; exit 0; else exit 1; fi"]
+    onExited: function(exitCode) {
+      if (exitCode === 0) {
+        keepOpenRetries = 0
+        Qt.callLater(function() { root.open() })
+      } else if (keepOpenRetries < 4) {
+        // The flag write races the rebuild: the fresh instance can load
+        // before the touch lands. Retry briefly before giving up.
+        keepOpenRetries++
+        keepOpenRetry.restart()
+      }
+    }
+  }
+
+  property int keepOpenRetries: 0
+
+  Timer {
+    id: keepOpenRetry
+    interval: 150
+    repeat: false
+    onTriggered: {
+      if (!keepOpenFlagRead.running) keepOpenFlagRead.running = true
+    }
   }
 
   // ------------------------------------------------------------- open / close
@@ -1543,15 +1596,10 @@ Panel {
     })
   }
 
-  // Reopen marker so the panel stays on top across the bar rebuild that a
-  // move triggers. (Full keep-open machinery arrives in a later commit;
-  // this stub keeps this commit working on its own.)
-  function keepOpenAcrossRebuild() {
-  }
-
   function close() {
     root.installDialogOpen = false
     root.updatesPageOpen = false
+    root.layoutPageOpen = false
     root.removeConfirmOpen = false
     root.restartConfirmOpen = false
     root.removeSelectMode = false
@@ -1756,7 +1804,19 @@ Panel {
           }
 
           Button {
-            iconText: "\uf0ed"
+            iconText: "\uf0c9"
+            tooltipText: "Arrange bar layout"
+            foreground: root.contentForeground
+            accent: Color.accent
+            fontFamily: root.contentFontFamily
+            fontSize: Style.font.bodySmall
+            horizontalPadding: Style.space(10)
+            verticalPadding: Style.space(5)
+            onClicked: root.layoutPageOpen = true
+          }
+
+          Button {
+            iconText: ""
             tooltipText: "Install plugin"
             foreground: root.contentForeground
             accent: Color.accent
@@ -1973,6 +2033,23 @@ Panel {
       onOpenUrlRequested: function(url) { root.openExternal(url) }
       onUpdatePluginRequested: function(sourceKey) { root.updatePlugin(sourceKey) }
       onUpdateAllRequested: root.updateAll()
+    }
+
+    Arrange.Page {
+      id: layoutPage
+      anchors.fill: parent
+      z: 5000
+
+      open: root.layoutPageOpen
+      sections: root.barLayoutSections
+      foreground: root.contentForeground
+      fontFamily: root.contentFontFamily
+      panelBackground: root.panelBackground
+
+      onCloseRequested: root.layoutPageOpen = false
+      onDropRequested: function(pluginId, section, index) {
+        root.moveWidgetToPosition(pluginId, section, index)
+      }
     }
 
 

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -269,6 +269,9 @@ Rectangle {
                     id: chipMouse
                     anchors.fill: parent
                     hoverEnabled: true
+                    // The enclosing ListView steals press-and-move for
+                    // scrolling otherwise; keep the grab for dragging.
+                    preventStealing: true
                     // Arrow at rest so chips read as a plain list; the hand
                     // only appears while a drag is actually in flight.
                     cursorShape: chipMouse.dragging ? Qt.ClosedHandCursor : Qt.ArrowCursor

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -266,9 +266,12 @@ Rectangle {
                   }
 
                   MouseArea {
+                    id: chipMouse
                     anchors.fill: parent
                     hoverEnabled: true
-                    cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                    // Arrow at rest so chips read as a plain list; the hand
+                    // only appears while a drag is actually in flight.
+                    cursorShape: chipMouse.dragging ? Qt.ClosedHandCursor : Qt.ArrowCursor
                     acceptedButtons: Qt.LeftButton
 
                     property real pressX: 0

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -10,6 +10,12 @@ import qs.Ui
 // widgets in live order. Drag a chip within a column to reorder, or across
 // columns to move sections. Every drop calls back with (id, section, index)
 // and the owner applies it with `omarchy bar move`, so the bar follows.
+//
+// Interaction notes:
+// - The dragged chip stays in place as a dimmed placeholder; a thin accent
+//   line marks the exact insertion point. Neither changes delegate heights,
+//   so the list never shifts under the cursor mid-drag.
+// - Plain hover does nothing — only an active drag shows indicators.
 Rectangle {
   id: board
 
@@ -32,23 +38,31 @@ Rectangle {
 
   // Active drag state, shared across the three columns.
   property string dragId: ""
+  property string dragName: ""
   property string dragFromSection: ""
   property int dragFromIndex: -1
   property string dropSection: ""
   property int dropIndex: -1
+  property real ghostX: 0
+  property real ghostY: 0
 
-  function startDrag(id, section, index) {
+  function startDrag(id, name, section, index, x, y) {
     board.dragId = id
+    board.dragName = name
     board.dragFromSection = section
     board.dragFromIndex = index
     board.dropSection = section
     board.dropIndex = index
+    board.ghostX = x
+    board.ghostY = y
   }
 
-  function moveDrag(section, index) {
+  function moveDrag(section, index, x, y) {
     if (board.dragId === "") return
     board.dropSection = section
     board.dropIndex = index
+    board.ghostX = x
+    board.ghostY = y
   }
 
   function endDrag() {
@@ -59,6 +73,7 @@ Rectangle {
     var fromSection = board.dragFromSection
     var fromIndex = board.dragFromIndex
     board.dragId = ""
+    board.dragName = ""
     board.dragFromSection = ""
     board.dragFromIndex = -1
     board.dropSection = ""
@@ -72,6 +87,7 @@ Rectangle {
 
   function cancelDrag() {
     board.dragId = ""
+    board.dragName = ""
     board.dragFromSection = ""
     board.dragFromIndex = -1
     board.dropSection = ""
@@ -111,7 +127,7 @@ Rectangle {
     }
 
     Label {
-      text: "Drag widgets within or across sections to reorder the bar."
+      text: "Drag a widget to reorder — within its section or across sections."
       textFormat: Text.PlainText
       color: Qt.darker(board.foreground, 1.5)
       font.family: board.fontFamily
@@ -133,6 +149,7 @@ Rectangle {
 
           readonly property string section: modelData.section
           readonly property var entries: modelData.entries
+          readonly property bool isDropColumn: board.dragId !== "" && board.dropSection === column.section
 
           Layout.fillWidth: true
           Layout.fillHeight: true
@@ -152,10 +169,10 @@ Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
             radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
-            color: board.dropSection === column.section && board.dragId !== ""
+            color: column.isDropColumn
               ? Util.alpha(Color.accent, 0.08)
               : Util.alpha(board.foreground, 0.04)
-            border.color: board.dropSection === column.section && board.dragId !== ""
+            border.color: column.isDropColumn
               ? Util.alpha(Color.accent, 0.5)
               : Util.alpha(board.foreground, 0.12)
             border.width: 1
@@ -178,43 +195,33 @@ Rectangle {
                 readonly property string widgetId: modelData.id
                 readonly property string widgetName: modelData.name
                 readonly property bool isDragged: board.dragId === widgetId
-                readonly property bool isDropBefore: board.dragId !== ""
+                // Insertion line sits above this chip.
+                readonly property bool showLineAbove: board.dragId !== ""
                   && board.dropSection === column.section
-                  && board.dropIndex === chip.index
-                readonly property bool isDropAfter: board.dragId !== ""
+                  && board.dropIndex === index
+                // Insertion line sits below the last chip.
+                readonly property bool showLineBelow: board.dragId !== ""
                   && board.dropSection === column.section
-                  && board.dropIndex === chip.index + 1
-                  && chip.index === sectionList.count - 1
+                  && board.dropIndex === index + 1
+                  && index === sectionList.count - 1
 
                 width: sectionList.width
-                height: chipCard.height + (isDropBefore ? Style.space(30) : 0) + (isDropAfter ? Style.space(30) : 0)
-
-                // Drop indicator above the chip.
-                Rectangle {
-                  visible: chip.isDropBefore
-                  anchors.top: parent.top
-                  anchors.left: parent.left
-                  anchors.right: parent.right
-                  height: Style.space(26)
-                  radius: height / 2
-                  color: Util.alpha(Color.accent, 0.25)
-                }
+                // Fixed height: the drop line is an overlay and never
+                // changes delegate geometry, so the list stays still.
+                height: Style.space(34)
 
                 Rectangle {
                   id: chipCard
-                  anchors.left: parent.left
-                  anchors.right: parent.right
-                  y: chip.isDropBefore ? Style.space(30) : 0
-                  height: Style.space(34)
+                  anchors.fill: parent
                   radius: height / 2
                   color: chip.isDragged
-                    ? Util.alpha(Color.accent, 0.3)
+                    ? Util.alpha(Color.accent, 0.25)
                     : Style.normalFillFor(board.foreground, Color.accent)
                   border.color: chip.isDragged
                     ? Color.accent
                     : Util.alpha(board.foreground, 0.15)
                   border.width: 1
-                  opacity: chip.isDragged ? 0.7 : 1.0
+                  opacity: chip.isDragged ? 0.55 : 1.0
 
                   RowLayout {
                     anchors.fill: parent
@@ -238,7 +245,6 @@ Rectangle {
                       color: board.foreground
                       font.family: board.fontFamily
                       font.pixelSize: Style.font.bodySmall
-                      font.bold: chip.isDragged
                       Layout.fillWidth: true
                       Layout.alignment: Qt.AlignVCenter
                     }
@@ -249,11 +255,9 @@ Rectangle {
                     hoverEnabled: true
                     cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
                     acceptedButtons: Qt.LeftButton
-                    drag.target: dragProxy
-                    drag.axis: Drag.XAndYAxis
 
-                    property int pressX: 0
-                    property int pressY: 0
+                    property real pressX: 0
+                    property real pressY: 0
                     property bool dragging: false
 
                     onPressed: function(mouse) {
@@ -265,10 +269,13 @@ Rectangle {
                       if (!dragging
                         && (Math.abs(mouse.x - pressX) > 6 || Math.abs(mouse.y - pressY) > 6)) {
                         dragging = true
-                        board.startDrag(chip.widgetId, column.section, chip.index)
+                        // NOTE: bare `index` — the Repeater context property.
+                        // `chip.index` does not resolve and breaks drop math.
+                        var start = board.mapFromItem(chip, mouse.x, mouse.y)
+                        board.startDrag(chip.widgetId, chip.widgetName, column.section, index, start.x, start.y)
                       }
                       if (dragging) {
-                        var p = chip.mapToItem(board, mouse.x, mouse.y)
+                        var p = board.mapFromItem(chip, mouse.x, mouse.y)
                         board.updateDropTarget(p.x, p.y)
                       }
                     }
@@ -279,24 +286,41 @@ Rectangle {
                   }
                 }
 
-                // Drop indicator below the last chip.
+                // Insertion marker: a thin accent line overlaid at the top
+                // edge (or bottom edge for the end-of-list slot). Overlay —
+                // never affects layout, never shifts siblings.
                 Rectangle {
-                  visible: chip.isDropAfter
-                  anchors.bottom: parent.bottom
+                  visible: chip.showLineAbove
+                  anchors.top: parent.top
+                  anchors.topMargin: -Style.space(3)
                   anchors.left: parent.left
                   anchors.right: parent.right
-                  height: Style.space(26)
+                  height: Style.space(3)
                   radius: height / 2
-                  color: Util.alpha(Color.accent, 0.25)
+                  color: Color.accent
+                }
+
+                Rectangle {
+                  visible: chip.showLineBelow
+                  anchors.bottom: parent.bottom
+                  anchors.bottomMargin: -Style.space(3)
+                  anchors.left: parent.left
+                  anchors.right: parent.right
+                  height: Style.space(3)
+                  radius: height / 2
+                  color: Color.accent
                 }
               }
 
-              // Empty column still accepts drops.
+              // Empty column still accepts drops: any motion over it targets
+              // index 0, release commits the move.
               MouseArea {
                 anchors.fill: parent
                 visible: sectionList.count === 0
-                onPressed: function(mouse) {
-                  if (board.dragId !== "") board.moveDrag(column.section, 0)
+                onPositionChanged: function(mouse) {
+                  if (board.dragId === "") return
+                  var p = board.mapFromItem(sectionList, mouse.x, mouse.y)
+                  board.moveDrag(column.section, 0, p.x, p.y)
                 }
                 onReleased: {
                   if (board.dragId !== "") board.endDrag()
@@ -309,12 +333,34 @@ Rectangle {
     }
   }
 
-  // Floating ghost following the cursor during a drag.
+  // Ghost chip following the cursor during a drag.
   Rectangle {
-    id: dragProxy
-    visible: false
-    width: 0
-    height: 0
+    id: ghost
+    visible: board.dragId !== ""
+    width: Math.min(Style.space(200), board.width / 3 - Style.space(16))
+    height: Style.space(34)
+    radius: height / 2
+    color: Util.alpha(Color.accent, 0.85)
+    border.color: Color.accent
+    border.width: 1
+    x: board.ghostX - width / 2
+    y: board.ghostY - height / 2
+    z: 100
+    opacity: 0.9
+
+    Text {
+      anchors.centerIn: parent
+      width: parent.width - Style.space(16)
+      horizontalAlignment: Text.AlignHCenter
+      elide: Text.ElideRight
+      maximumLineCount: 1
+      text: board.dragName
+      textFormat: Text.PlainText
+      color: Color.background
+      font.family: board.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      font.bold: true
+    }
   }
 
   function updateDropTarget(x, y) {
@@ -324,10 +370,10 @@ Rectangle {
       var list = board._lists[names[i]]
       if (!list) continue
       var p = board.mapToItem(list, x, y)
-      if (p.x < 0 || p.y < -Style.space(40) || p.x > list.width
+      if (p.x < -Style.space(20) || p.y < -Style.space(40) || p.x > list.width + Style.space(20)
         || p.y > list.height + Style.space(40)) continue
       var idx = list.indexAt(list.width / 2, Math.max(0, Math.min(list.height - 1, p.y)))
-      board.moveDrag(names[i], idx === -1 ? list.count : idx)
+      board.moveDrag(names[i], idx === -1 ? list.count : idx, x, y)
       return
     }
   }
@@ -339,5 +385,20 @@ Rectangle {
     for (var k in board._lists) next[k] = board._lists[k]
     next[section] = list
     board._lists = next
+  }
+
+  // Position tracker covering gaps between chips and column padding.
+  // NoButton: tracks motion without stealing press/release from chips.
+  // Release always lands on the chip holding the mouse grab, so its own
+  // onReleased commits the drop no matter where the cursor ends up.
+  MouseArea {
+    anchors.fill: parent
+    enabled: board.dragId !== ""
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    z: 50
+    onPositionChanged: function(mouse) {
+      board.updateDropTarget(mouse.x, mouse.y)
+    }
   }
 }

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -284,6 +284,11 @@ Rectangle {
                       dragging = false
                     }
                     onPositionChanged: function(mouse) {
+                      // Ignore pure hover: a drag starts only while the left
+                      // button is held. Without this gate, the first hover
+                      // motion trips the threshold (pressX/pressY start at 0)
+                      // and a phantom drag follows the cursor uninvited.
+                      if (!(mouse.buttons & Qt.LeftButton)) return
                       if (!dragging
                         && (Math.abs(mouse.x - pressX) > 6 || Math.abs(mouse.y - pressY) > 6)) {
                         dragging = true

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -1,0 +1,343 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import qs.Commons
+import qs.Ui
+
+// Bar-layout board: the three bar sections side by side, each showing its
+// widgets in live order. Drag a chip within a column to reorder, or across
+// columns to move sections. Every drop calls back with (id, section, index)
+// and the owner applies it with `omarchy bar move`, so the bar follows.
+Rectangle {
+  id: board
+
+  required property bool open
+  required property var sections
+  required property color foreground
+  required property string fontFamily
+  required property color panelBackground
+
+  signal closeRequested
+  signal dropRequested(string pluginId, string section, int index)
+
+  visible: open
+  color: panelBackground
+
+  property bool _stayLoaded: false
+  onOpenChanged: {
+    if (open) _stayLoaded = true
+  }
+
+  // Active drag state, shared across the three columns.
+  property string dragId: ""
+  property string dragFromSection: ""
+  property int dragFromIndex: -1
+  property string dropSection: ""
+  property int dropIndex: -1
+
+  function startDrag(id, section, index) {
+    board.dragId = id
+    board.dragFromSection = section
+    board.dragFromIndex = index
+    board.dropSection = section
+    board.dropIndex = index
+  }
+
+  function moveDrag(section, index) {
+    if (board.dragId === "") return
+    board.dropSection = section
+    board.dropIndex = index
+  }
+
+  function endDrag() {
+    if (board.dragId === "") return
+    var id = board.dragId
+    var section = board.dropSection
+    var index = board.dropIndex
+    var fromSection = board.dragFromSection
+    var fromIndex = board.dragFromIndex
+    board.dragId = ""
+    board.dragFromSection = ""
+    board.dragFromIndex = -1
+    board.dropSection = ""
+    board.dropIndex = -1
+    // No-op when dropped back where it started.
+    if (section === fromSection && (index === fromIndex || index === fromIndex + 1)) return
+    // Account for the removal shift when moving down within one column.
+    var target = (section === fromSection && index > fromIndex) ? index - 1 : index
+    board.dropRequested(id, section, target)
+  }
+
+  function cancelDrag() {
+    board.dragId = ""
+    board.dragFromSection = ""
+    board.dragFromIndex = -1
+    board.dropSection = ""
+    board.dropIndex = -1
+  }
+
+  ColumnLayout {
+    anchors.fill: parent
+    anchors.margins: Style.space(16)
+    spacing: Style.space(10)
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: Style.space(8)
+
+      Label {
+        text: "Bar Layout"
+        color: board.foreground
+        font.family: board.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+        Layout.fillWidth: true
+      }
+
+      Button {
+        text: "Back"
+        tooltipText: "Back to plugin list"
+        bordered: true
+        foreground: board.foreground
+        accent: Color.accent
+        fontFamily: board.fontFamily
+        fontSize: Style.font.bodySmall
+        horizontalPadding: Style.space(10)
+        verticalPadding: Style.space(5)
+        onClicked: board.closeRequested()
+      }
+    }
+
+    Label {
+      text: "Drag widgets within or across sections to reorder the bar."
+      textFormat: Text.PlainText
+      color: Qt.darker(board.foreground, 1.5)
+      font.family: board.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      Layout.fillWidth: true
+    }
+
+    RowLayout {
+      Layout.fillWidth: true
+      Layout.fillHeight: true
+      spacing: Style.space(8)
+
+      Repeater {
+        model: board.sections
+
+        ColumnLayout {
+          id: column
+          required property var modelData
+
+          readonly property string section: modelData.section
+          readonly property var entries: modelData.entries
+
+          Layout.fillWidth: true
+          Layout.fillHeight: true
+          spacing: Style.space(6)
+
+          Label {
+            text: column.section.toUpperCase()
+            color: board.foreground
+            font.family: board.fontFamily
+            font.pixelSize: Style.font.caption
+            font.bold: true
+            horizontalAlignment: Text.AlignHCenter
+            Layout.fillWidth: true
+          }
+
+          Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            radius: Style.cornerRadius > 0 ? Style.cornerRadius : 4
+            color: board.dropSection === column.section && board.dragId !== ""
+              ? Util.alpha(Color.accent, 0.08)
+              : Util.alpha(board.foreground, 0.04)
+            border.color: board.dropSection === column.section && board.dragId !== ""
+              ? Util.alpha(Color.accent, 0.5)
+              : Util.alpha(board.foreground, 0.12)
+            border.width: 1
+
+            ListView {
+              id: sectionList
+              anchors.fill: parent
+              anchors.margins: Style.space(6)
+              clip: true
+              spacing: Style.space(4)
+              model: column.entries
+
+              Component.onCompleted: board.registerList(column.section, sectionList)
+
+              delegate: Item {
+                id: chip
+                required property var modelData
+                required property int index
+
+                readonly property string widgetId: modelData.id
+                readonly property string widgetName: modelData.name
+                readonly property bool isDragged: board.dragId === widgetId
+                readonly property bool isDropBefore: board.dragId !== ""
+                  && board.dropSection === column.section
+                  && board.dropIndex === chip.index
+                readonly property bool isDropAfter: board.dragId !== ""
+                  && board.dropSection === column.section
+                  && board.dropIndex === chip.index + 1
+                  && chip.index === sectionList.count - 1
+
+                width: sectionList.width
+                height: chipCard.height + (isDropBefore ? Style.space(30) : 0) + (isDropAfter ? Style.space(30) : 0)
+
+                // Drop indicator above the chip.
+                Rectangle {
+                  visible: chip.isDropBefore
+                  anchors.top: parent.top
+                  anchors.left: parent.left
+                  anchors.right: parent.right
+                  height: Style.space(26)
+                  radius: height / 2
+                  color: Util.alpha(Color.accent, 0.25)
+                }
+
+                Rectangle {
+                  id: chipCard
+                  anchors.left: parent.left
+                  anchors.right: parent.right
+                  y: chip.isDropBefore ? Style.space(30) : 0
+                  height: Style.space(34)
+                  radius: height / 2
+                  color: chip.isDragged
+                    ? Util.alpha(Color.accent, 0.3)
+                    : Style.normalFillFor(board.foreground, Color.accent)
+                  border.color: chip.isDragged
+                    ? Color.accent
+                    : Util.alpha(board.foreground, 0.15)
+                  border.width: 1
+                  opacity: chip.isDragged ? 0.7 : 1.0
+
+                  RowLayout {
+                    anchors.fill: parent
+                    anchors.leftMargin: Style.space(8)
+                    anchors.rightMargin: Style.space(8)
+                    spacing: Style.space(6)
+
+                    Text {
+                      text: "⋮⋮"
+                      color: Qt.darker(board.foreground, 1.4)
+                      font.family: board.fontFamily
+                      font.pixelSize: Style.font.caption
+                      Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Text {
+                      text: chip.widgetName
+                      textFormat: Text.PlainText
+                      elide: Text.ElideRight
+                      maximumLineCount: 1
+                      color: board.foreground
+                      font.family: board.fontFamily
+                      font.pixelSize: Style.font.bodySmall
+                      font.bold: chip.isDragged
+                      Layout.fillWidth: true
+                      Layout.alignment: Qt.AlignVCenter
+                    }
+                  }
+
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                    acceptedButtons: Qt.LeftButton
+                    drag.target: dragProxy
+                    drag.axis: Drag.XAndYAxis
+
+                    property int pressX: 0
+                    property int pressY: 0
+                    property bool dragging: false
+
+                    onPressed: function(mouse) {
+                      pressX = mouse.x
+                      pressY = mouse.y
+                      dragging = false
+                    }
+                    onPositionChanged: function(mouse) {
+                      if (!dragging
+                        && (Math.abs(mouse.x - pressX) > 6 || Math.abs(mouse.y - pressY) > 6)) {
+                        dragging = true
+                        board.startDrag(chip.widgetId, column.section, chip.index)
+                      }
+                      if (dragging) {
+                        var p = chip.mapToItem(board, mouse.x, mouse.y)
+                        board.updateDropTarget(p.x, p.y)
+                      }
+                    }
+                    onReleased: {
+                      if (dragging) board.endDrag()
+                      dragging = false
+                    }
+                  }
+                }
+
+                // Drop indicator below the last chip.
+                Rectangle {
+                  visible: chip.isDropAfter
+                  anchors.bottom: parent.bottom
+                  anchors.left: parent.left
+                  anchors.right: parent.right
+                  height: Style.space(26)
+                  radius: height / 2
+                  color: Util.alpha(Color.accent, 0.25)
+                }
+              }
+
+              // Empty column still accepts drops.
+              MouseArea {
+                anchors.fill: parent
+                visible: sectionList.count === 0
+                onPressed: function(mouse) {
+                  if (board.dragId !== "") board.moveDrag(column.section, 0)
+                }
+                onReleased: {
+                  if (board.dragId !== "") board.endDrag()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Floating ghost following the cursor during a drag.
+  Rectangle {
+    id: dragProxy
+    visible: false
+    width: 0
+    height: 0
+  }
+
+  function updateDropTarget(x, y) {
+    if (board.dragId === "") return
+    var names = ["left", "center", "right"]
+    for (var i = 0; i < names.length; i++) {
+      var list = board._lists[names[i]]
+      if (!list) continue
+      var p = board.mapToItem(list, x, y)
+      if (p.x < 0 || p.y < -Style.space(40) || p.x > list.width
+        || p.y > list.height + Style.space(40)) continue
+      var idx = list.indexAt(list.width / 2, Math.max(0, Math.min(list.height - 1, p.y)))
+      board.moveDrag(names[i], idx === -1 ? list.count : idx)
+      return
+    }
+  }
+
+  property var _lists: ({})
+
+  function registerList(section, list) {
+    var next = {}
+    for (var k in board._lists) next[k] = board._lists[k]
+    next[section] = list
+    board._lists = next
+  }
+}

--- a/panel/layout/Page.qml
+++ b/panel/layout/Page.qml
@@ -33,7 +33,17 @@ Rectangle {
 
   property bool _stayLoaded: false
   onOpenChanged: {
-    if (open) _stayLoaded = true
+    if (open) {
+      _stayLoaded = true
+      // Never inherit a stale drag/selection look from a previous visit:
+      // the board always opens in a clean, unselected state.
+      cancelDrag()
+    }
+  }
+
+  focus: true
+  Keys.onEscapePressed: {
+    if (board.dragId !== "") board.cancelDrag()
   }
 
   // Active drag state, shared across the three columns.
@@ -184,6 +194,11 @@ Rectangle {
               clip: true
               spacing: Style.space(4)
               model: column.entries
+              // The board manages its own drop markers; never show the
+              // view's own current-item highlight or keep a selection.
+              currentIndex: -1
+              highlight: null
+              keyNavigationEnabled: false
 
               Component.onCompleted: board.registerList(column.section, sectionList)
 

--- a/panel/plugin/ContextMenu.qml
+++ b/panel/plugin/ContextMenu.qml
@@ -19,12 +19,15 @@ Rectangle {
   required property color foreground
   required property string fontFamily
   required property color panelBackground
+  property bool canMove: false
+  property string currentSection: ""
 
   signal closeRequested
   signal enabledChangeRequested(string pluginId, bool enabled)
   signal sourceRequested(string sourceKey)
   signal updateRequested(string sourceKey)
   signal removalRequested(string pluginId)
+  signal moveRequested(string pluginId, string section)
 
   visible: open
   color: "transparent"
@@ -108,6 +111,36 @@ Rectangle {
         onClicked: {
           menu.updateRequested(menu.plugin.sourceKey)
           menu.closeRequested()
+        }
+      }
+
+      // Bar-widget placement. Only visible for widgets currently on the bar;
+      // the widget's own section is marked and disabled so the menu shows
+      // where the widget lives now.
+      Repeater {
+        model: menu.canMove ? ["left", "center", "right"] : []
+
+        Button {
+          required property string modelData
+
+          readonly property bool isCurrent: menu.currentSection === modelData
+
+          visible: menu.canMove
+          text: (isCurrent ? "● " : "") + "Move to " + modelData
+          enabled: !isCurrent
+          opacity: isCurrent ? 0.55 : 1.0
+          foreground: menu.foreground
+          accent: Color.accent
+          fontFamily: menu.fontFamily
+          fontSize: Style.font.bodySmall
+          horizontalPadding: Style.space(8)
+          verticalPadding: Style.space(5)
+          Layout.fillWidth: true
+          Layout.alignment: Qt.AlignLeft
+          onClicked: {
+            menu.moveRequested(menu.plugin.id, modelData)
+            menu.closeRequested()
+          }
         }
       }
 


### PR DESCRIPTION
Adds bar-widget placement controls to the Plugin Manager: move widgets between sections from the row menu, and reorder everything via a drag-and-drop layout board.

## Part 1 — Move to left / center / right (row ⋮ menu)

- **ContextMenu.qml**: new `canMove`/`currentSection` props, `moveRequested(id, section)` signal, and a Repeater rendering the three section entries. The widget's own section is marked with ● and disabled; other plugin kinds never see the entries.
- **Panel.qml**: `barLayoutCache` (parsed from `shell.json`, refreshed on open and after every move), `barSectionFor()`, `canMoveWidget()`, `moveWidgetToSection()` driving `omarchy bar move` through a `barMoveProcess` — the same subprocess pattern upstream uses for enable/disable — plus a `moveSummary` footer status following the existing remove/update summary pattern.

## Part 2 — Keep panel open across actions

Every toggle/move/remove rewrites `shell.json` and the bar rebuilds all widgets in response, including this panel's own Loader — so the panel used to vanish after each action. A state-file flag (`~/.local/state/omarchy/omaplug-keep-open`) written before the action lets the fresh instance reopen itself (with a short retry for the write/rebuild race).

## Part 3 — Drag-and-drop Bar Layout board

New arrange page (`panel/layout/Page.qml`, opened from the ⋮⋮ header button) showing left/center/right sections in live order. Drag chips within or across columns; drops apply via `moveWidgetToPosition()` (`omarchy bar move --section … --index N`). Details: drop marker is a 3px overlay line that never shifts layout mid-drag, the dragged chip stays as a dimmed placeholder with a cursor ghost, hover alone never starts a drag (left-button gate), and chips keep their grab inside scrollable columns (`preventStealing`).

## Behavior

- Move entries only appear for `bar-widget` kinds currently placed in the bar; services, overlays, menus, and disabled widgets hide them.
- Placement hot-reloads — no shell restart needed.
- Rebased onto upstream `main` (v1.4.0): move logic rewritten from the removed shell-registry calls to the `omarchy bar move` subprocess pattern; no `root.registry` references remain.

## Verification

- Moved `vm.netspeed` right → center → right → indexed positions; `shell.json` updated correctly each time.
- Full drag cycle logged clean during testing (press → drag → drop committed, empty error).
- Panel rescans and shell restarts with no QML errors related to these changes.
